### PR TITLE
feat: migrate to redis-entraid for Entra ID authentication

### DIFF
--- a/src/app/redis_client.py
+++ b/src/app/redis_client.py
@@ -1,17 +1,27 @@
-import asyncio
+"""Azure Managed Redis client with Entra ID authentication.
+
+Uses redis-entraid credential_provider for automatic token management:
+- Automatic token refresh before expiry
+- Built-in re-authentication handling
+- Object ID extraction from token for Redis AUTH
+
+Reference:
+- https://learn.microsoft.com/en-us/azure/redis/python-get-started
+- https://learn.microsoft.com/en-us/azure/redis/entra-for-authentication
+"""
+
 import logging
 import time
 from contextlib import suppress
 from typing import Any, cast
 
 import redis.asyncio as aioredis
-from azure.identity.aio import DefaultAzureCredential
 from redis.asyncio.client import Redis
 from redis.asyncio.retry import Retry
 from redis.backoff import ExponentialBackoff
-from redis.exceptions import AuthenticationError
 from redis.exceptions import ConnectionError as RedisConnectionError
 from redis.exceptions import TimeoutError as RedisTimeoutError
+from redis_entraid.cred_provider import create_from_default_azure_credential
 
 from app.config import Settings
 from app.telemetry import record_redis_metrics
@@ -22,48 +32,32 @@ logger = logging.getLogger(__name__)
 class RedisClient:
     """Azure Managed Redis client with Entra ID authentication.
 
-    - Uses DefaultAzureCredential (aio) to obtain access tokens for scope
-      "https://redis.azure.com/.default".
-    - Username must be the managed identity client id (AZURE_CLIENT_ID).
-    - Handles token refresh and single retry on auth errors.
+    Uses redis-entraid credential_provider for:
+    - Automatic token acquisition via DefaultAzureCredential
+    - Automatic token refresh before expiry
+    - Object ID extraction from token for Redis AUTH username
+
+    Note: AZURE_CLIENT_ID environment variable is still required for
+    DefaultAzureCredential to select the correct User-Assigned Managed Identity.
     """
 
-    _SCOPE = "https://redis.azure.com/.default"
-    _TOKEN_REFRESH_SAFETY = 120  # seconds before expiry to refresh
+    _SCOPE = ("https://redis.azure.com/.default",)
 
     def __init__(self, host: str, port: int, settings: Settings) -> None:
         self._host = host
         self._port = port
         self._settings = settings
         self._client: Redis | None = None
-        self._credential: DefaultAzureCredential | None = None
-        self._access_token: str | None = None
-        self._access_token_exp: float = 0.0
-        self._token_lock = asyncio.Lock()
+        self._credential_provider: Any = None
 
-    async def _get_token(self) -> str:
-        """Get a valid access token, refreshing if near expiry.
+    def _build_client(self) -> Redis:
+        """Build Redis client with credential_provider for Entra ID auth.
 
-        Returns the token string to be used as Redis password.
+        The credential_provider handles:
+        - Token acquisition using DefaultAzureCredential
+        - Automatic token refresh before expiry
+        - Extracting Object ID from token for Redis AUTH username
         """
-        async with self._token_lock:
-            now = time.time()
-            if self._access_token and now < (
-                self._access_token_exp - self._TOKEN_REFRESH_SAFETY
-            ):
-                return self._access_token
-
-            if not self._credential:
-                # DefaultAzureCredential honors AZURE_CLIENT_ID to pick UAMI
-                self._credential = DefaultAzureCredential()
-
-            token = await self._credential.get_token(self._SCOPE)
-            self._access_token = token.token
-            # azure-identity returns AccessToken with expires_on epoch seconds
-            self._access_token_exp = float(token.expires_on or (now + 300))
-            return self._access_token
-
-    async def _build_client(self) -> Redis:
         retry = Retry(
             ExponentialBackoff(
                 base=self._settings.redis_backoff_base,
@@ -71,17 +65,16 @@ class RedisClient:
             ),
             retries=self._settings.redis_max_retries,
         )
-        username = self._settings.azure_client_id
-        if not username:
-            raise RuntimeError("AZURE_CLIENT_ID is required for Entra ID auth")
 
-        password = await self._get_token()
+        # redis-entraid handles token acquisition, refresh, and auth automatically
+        # DefaultAzureCredential will use AZURE_CLIENT_ID env var to select UAMI
+        self._credential_provider = create_from_default_azure_credential(self._SCOPE)
+
         client = aioredis.Redis(  # type: ignore[call-overload]
             host=self._host,
             port=self._port,
             ssl=self._settings.redis_ssl,
-            username=username,
-            password=password,
+            credential_provider=self._credential_provider,
             socket_timeout=self._settings.redis_socket_timeout,
             socket_connect_timeout=self._settings.redis_socket_connect_timeout,
             max_connections=self._settings.redis_max_connections,
@@ -93,7 +86,8 @@ class RedisClient:
         return cast(Redis, client)
 
     async def connect(self) -> None:
-        self._client = await self._build_client()
+        """Connect to Redis and verify connectivity."""
+        self._client = self._build_client()
         await self._client.ping()
 
     async def reset_connections(self) -> int:
@@ -106,7 +100,6 @@ class RedisClient:
         count = 0
         try:
             pool = self._client.connection_pool
-            # redis-py doesn't expose a direct count; disconnect and return 1 as a signal
             await pool.disconnect(inuse_connections=True)
             count = 1
         except Exception as e:  # noqa: BLE001
@@ -114,41 +107,39 @@ class RedisClient:
         return count
 
     async def close(self) -> None:
+        """Close Redis client and cleanup resources."""
         if self._client:
             await self._client.aclose()  # type: ignore[attr-defined]
             self._client = None
-        if self._credential:
-            await self._credential.close()
-            self._credential = None
-
-    async def _with_auth_retry(self, func: str, *args: Any, **kwargs: Any) -> Any:
-        if not self._client:
-            raise RuntimeError("Redis client is not connected")
-        try:
-            return await getattr(self._client, func)(*args, **kwargs)
-        except AuthenticationError:
-            # refresh token and rebuild client, then retry once
-            await asyncio.sleep(0.1)
-            self._access_token = None
-            self._access_token_exp = 0.0
-            self._client = await self._build_client()
-            return await getattr(self._client, func)(*args, **kwargs)
+        self._credential_provider = None
 
     async def get(self, key: str) -> str | None:
-        res = await self._with_auth_retry("get", key)
+        """Get value by key."""
+        if not self._client:
+            raise RuntimeError("Redis client is not connected")
+        res = await self._client.get(key)
         return cast(str | None, res)
 
     async def set(self, key: str, value: str) -> None:
-        await self._with_auth_retry("set", key, value)
+        """Set key-value pair."""
+        if not self._client:
+            raise RuntimeError("Redis client is not connected")
+        await self._client.set(key, value)
 
     async def increment(self, key: str) -> int:
-        val = await self._with_auth_retry("incr", key)
+        """Increment key value."""
+        if not self._client:
+            raise RuntimeError("Redis client is not connected")
+        val = await self._client.incr(key)
         return int(cast(int, val))
 
     async def ping(self) -> bool:
+        """Ping Redis and record metrics."""
+        if not self._client:
+            raise RuntimeError("Redis client is not connected")
         start = time.time()
         try:
-            res = await self._with_auth_retry("ping")
+            res = await self._client.ping()
             latency_ms = int((time.time() - start) * 1000)
             with suppress(Exception):
                 record_redis_metrics(True, latency_ms)

--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -8,6 +8,7 @@ dependencies = [
   "uvicorn>=0.27.0",
   "redis>=5.0.0",
   "azure-identity>=1.15.0",
+  "redis-entraid>=0.3.0",
   "aiohttp>=3.9.0",
   "azure-monitor-opentelemetry>=1.2.0",
   "opentelemetry-instrumentation-redis>=0.46b0",

--- a/src/uv.lock
+++ b/src/uv.lock
@@ -72,6 +72,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "redis" },
+    { name = "redis-entraid" },
     { name = "starlette" },
     { name = "uvicorn" },
 ]
@@ -103,6 +104,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.5.0" },
     { name = "pydantic-settings", specifier = ">=2.1.0" },
     { name = "redis", specifier = ">=5.0.0" },
+    { name = "redis-entraid", specifier = ">=0.3.0" },
     { name = "starlette", specifier = ">=0.49.1" },
     { name = "uvicorn", specifier = ">=0.27.0" },
 ]
@@ -1618,6 +1620,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0d/d6/e8b92798a5bd67d659d51a18170e91c16ac3b59738d91894651ee255ed49/redis-6.4.0.tar.gz", hash = "sha256:b01bc7282b8444e28ec36b261df5375183bb47a07eb9c603f284e89cbc5ef010", size = 4647399, upload-time = "2025-08-07T08:10:11.441Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e8/02/89e2ed7e85db6c93dfa9e8f691c5087df4e3551ab39081a4d7c6d1f90e05/redis-6.4.0-py3-none-any.whl", hash = "sha256:f0544fa9604264e9464cdf4814e7d4830f74b165d52f2a330a760a88dd248b7f", size = 279847, upload-time = "2025-08-07T08:10:09.84Z" },
+]
+
+[[package]]
+name = "redis-entraid"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-identity" },
+    { name = "msal" },
+    { name = "pyjwt" },
+    { name = "redis" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d8/f3/49df8f999bc80f51440836cf217a7ee43e991ac11af13cd4efdf0a64c39c/redis_entraid-1.1.0.tar.gz", hash = "sha256:700403401c3950f0f3dbda12fb26cf269b421bac47e3b56baf90354dc22d8d00", size = 9733, upload-time = "2025-12-11T08:25:50.645Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/17/20/7524da8bc7747bc6a80009839eb3212979ea964d3c4b1c7d87dbcd719579/redis_entraid-1.1.0-py3-none-any.whl", hash = "sha256:7bd995da24f57121cb54cb5912d68539ac09ade93aadf8887c994174fd255587", size = 7960, upload-time = "2025-12-11T08:25:49.435Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Replace manual token management with redis-entraid credential_provider
- Automatic token refresh before expiry (managed by redis-entraid)
- Automatic Object ID extraction from token for Redis AUTH
- Remove _get_token(), _with_auth_retry() manual implementations
- Simplify _build_client() to synchronous method
- Add redis-entraid>=0.3.0 dependency

Benefits:
- Follows Microsoft official guidance for Azure Managed Redis
- Reduces custom code and potential bugs
- Built-in re-authentication handling

Reference:
- https://learn.microsoft.com/en-us/azure/redis/python-get-started
- https://learn.microsoft.com/en-us/azure/redis/entra-for-authentication
