### PR TITLE
fix: MCPツール名からプリフィックスを削除

### DIFF
--- a/.github/skills/bicep-what-if-analysis/SKILL.md
+++ b/.github/skills/bicep-what-if-analysis/SKILL.md
@@ -12,8 +12,8 @@ description: azd up/provision や Bicep 変更の影響分析（what-if実行と
 
 | Tool | Use For |
 |------|---------|
-| `MS-Learn-microsoft_docs_search` | ノイズ判断が難しい場合のドキュメント検索 |
-| `MS-Learn-microsoft_docs_fetch` | 詳細なプロパティ仕様の取得 |
+| `microsoft_docs_search` | ノイズ判断が難しい場合のドキュメント検索 |
+| `microsoft_docs_fetch` | 詳細なプロパティ仕様の取得 |
 
 ## クイックスタート
 


### PR DESCRIPTION
## 概要

SKILL.mdのToolsセクションで使用していた`MS-Learn-`プリフィックスは実行環境依存のため、MCPサーバーの標準的なツール名に修正しました。

## 変更内容

- `MS-Learn-microsoft_docs_search` → `microsoft_docs_search`
- `MS-Learn-microsoft_docs_fetch` → `microsoft_docs_fetch`