### PR TITLE
chore: Bicep APIバージョンを最新GA版に更新

### DIFF
--- a/infra/modules/acr.bicep
+++ b/infra/modules/acr.bicep
@@ -13,7 +13,7 @@ param privateEndpointSubnetId string
 @description('Principal object IDs to grant AcrPull role (optional)')
 param principalObjectIds array = []
 
-resource containerRegistry 'Microsoft.ContainerRegistry/registries@2023-11-01-preview' = {
+resource containerRegistry 'Microsoft.ContainerRegistry/registries@2025-11-01' = {
   name: registryName
   location: location
   tags: tags

--- a/infra/modules/aks.bicep
+++ b/infra/modules/aks.bicep
@@ -185,7 +185,7 @@ var aksBaseProperties = union(aksCommonProperties, aksBaseSpecificProperties)
 var aksAutomaticProperties = union(aksCommonProperties, aksAutomaticSpecificProperties)
 
 // User Assigned Managed Identity for AKS cluster
-resource aksIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+resource aksIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' = {
   name: 'id-${aksName}'
   location: location
   tags: tags

--- a/infra/modules/azmonitor/container-insights.bicep
+++ b/infra/modules/azmonitor/container-insights.bicep
@@ -86,7 +86,7 @@ var streamWithKubeMonAgentEvents = union(selectedStreams, [
   'Microsoft-KubeMonAgentEvents'
 ])
 
-resource dataCollectionRule 'Microsoft.Insights/dataCollectionRules@2023-03-11' = {
+resource dataCollectionRule 'Microsoft.Insights/dataCollectionRules@2024-03-11' = {
   name: dataCollectionRuleName
   location: location
   tags: tags
@@ -133,7 +133,7 @@ resource existingAksCluster 'Microsoft.ContainerService/managedClusters@2025-06-
   name: aksClusterName
 }
 
-resource dataCollectionRuleAssociation 'Microsoft.Insights/dataCollectionRuleAssociations@2023-03-11' = {
+resource dataCollectionRuleAssociation 'Microsoft.Insights/dataCollectionRuleAssociations@2024-03-11' = {
   name: dataCollectionRuleAssociationName
   scope: existingAksCluster
   properties: {

--- a/infra/modules/azmonitor/core.bicep
+++ b/infra/modules/azmonitor/core.bicep
@@ -7,7 +7,7 @@ param logAnalyticsName string
 @description('App Insights name')
 param applicationInsightsName string
 
-resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2023-09-01' = {
+resource logAnalyticsWorkspace 'Microsoft.OperationalInsights/workspaces@2025-07-01' = {
   name: logAnalyticsName
   location: location
   tags: tags

--- a/infra/modules/identity.bicep
+++ b/infra/modules/identity.bicep
@@ -21,13 +21,13 @@ param audience string = 'api://AzureADTokenExchange'
 
 var federatedIdentitySubject = 'system:serviceaccount:${serviceAccountNamespace}:${serviceAccountName}'
 
-resource userAssignedManagedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2023-01-31' = {
+resource userAssignedManagedIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-30' = {
   name: identityName
   location: location
   tags: tags
 }
 
-resource federatedIdentityCredential 'Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials@2023-01-31' = {
+resource federatedIdentityCredential 'Microsoft.ManagedIdentity/userAssignedIdentities/federatedIdentityCredentials@2024-11-30' = {
   name: 'k8s-${serviceAccountNamespace}-${serviceAccountName}'
   parent: userAssignedManagedIdentity
   properties: {

--- a/infra/modules/network.bicep
+++ b/infra/modules/network.bicep
@@ -90,7 +90,7 @@ resource aksSubnetNetworkSecurityGroup 'Microsoft.Network/networkSecurityGroups@
   }
 }
 
-resource ingressPublicIP 'Microsoft.Network/publicIPAddresses@2023-04-01' = {
+resource ingressPublicIP 'Microsoft.Network/publicIPAddresses@2024-07-01' = {
   name: 'pip-ingress-${resourceToken}'
   location: location
   tags: tags

--- a/infra/modules/prometheus/pipeline.bicep
+++ b/infra/modules/prometheus/pipeline.bicep
@@ -24,7 +24,7 @@ var dataCollectionEndpointName = substring(
 var dataCollectionRuleName = substring(dataCollectionRuleNameBase, 0, min(64, length(dataCollectionRuleNameBase)))
 var dataCollectionRuleAssociationName = 'dcra-prom-${nameSuffix}'
 
-resource dataCollectionEndpoint 'Microsoft.Insights/dataCollectionEndpoints@2023-03-11' = {
+resource dataCollectionEndpoint 'Microsoft.Insights/dataCollectionEndpoints@2024-03-11' = {
   name: dataCollectionEndpointName
   location: location
   tags: tags
@@ -32,7 +32,7 @@ resource dataCollectionEndpoint 'Microsoft.Insights/dataCollectionEndpoints@2023
   properties: {}
 }
 
-resource dataCollectionRule 'Microsoft.Insights/dataCollectionRules@2023-03-11' = {
+resource dataCollectionRule 'Microsoft.Insights/dataCollectionRules@2024-03-11' = {
   name: dataCollectionRuleName
   location: location
   tags: tags
@@ -73,7 +73,7 @@ resource existingAksCluster 'Microsoft.ContainerService/managedClusters@2025-06-
   name: aksClusterName
 }
 
-resource dataCollectionRuleAssociation 'Microsoft.Insights/dataCollectionRuleAssociations@2023-03-11' = {
+resource dataCollectionRuleAssociation 'Microsoft.Insights/dataCollectionRuleAssociations@2024-03-11' = {
   name: dataCollectionRuleAssociationName
   scope: existingAksCluster
   properties: {

--- a/infra/modules/redis.bicep
+++ b/infra/modules/redis.bicep
@@ -89,7 +89,7 @@ output redisId string = redisEnterprise.id
 output redisHost string = redisEnterprise.properties.hostName
 output redisPort int = 10000
 
-resource redisAccessPolicyAssignment 'Microsoft.Cache/redisEnterprise/databases/accessPolicyAssignments@2025-04-01' = if (!empty(principalObjectId)) {
+resource redisAccessPolicyAssignment 'Microsoft.Cache/redisEnterprise/databases/accessPolicyAssignments@2025-07-01' = if (!empty(principalObjectId)) {
   name: 'app'
   parent: redisEnterpriseDatabase
   properties: {


### PR DESCRIPTION
## 概要

BicepファイルのAzure リソースAPIバージョンを最新GA版に更新しました。

## 更新内容

| リソースタイプ | 更新前 | 更新後 |
|---------------|--------|--------|
| userAssignedIdentities | 2023-01-31 | 2024-11-30 |
| dataCollectionEndpoints | 2023-03-11 | 2024-03-11 |
| dataCollectionRules | 2023-03-11 | 2024-03-11 |
| dataCollectionRuleAssociations | 2023-03-11 | 2024-03-11 |
| workspaces | 2023-09-01 | 2025-07-01 |
| registries | 2023-11-01-preview | 2025-11-01 |
| accessPolicyAssignments | 2025-04-01 | 2025-07-01 |

## スキップしたリソース

| リソースタイプ | 理由 |
|---------------|------|
| Microsoft.Network系 | Bicep型定義未対応(BCP081警告)のため現行維持 |
| AKS managedClusters | プレビュー機能(FQDN Network Policy)使用中 |
| Fleet | プレビュー機能(Approval Gate)使用中 |

## 検証

- `az bicep build` でLinter検証済み
- what-if分析で破壊的変更がないことを確認済み