### PR TITLE
chore: remove unnecessary related skills sections

### DIFF
--- a/.github/skills/aks-maintenance-checker/SKILL.md
+++ b/.github/skills/aks-maintenance-checker/SKILL.md
@@ -3,7 +3,7 @@ name: aks-maintenance-checker
 description: AKSクラスターおよびFleet Managerのメンテナンス状況（予定・実行中・完了・失敗）を確認。「メンテナンス状況」「アップグレード履歴」「Fleet更新状態」を求める場合に使用。
 ---
 
-# AKS Maintenance Events
+# AKS Maintenance Events Checker
 
 AKSクラスターおよびAzure Kubernetes Fleet Managerの実際のメンテナンスイベントを確認する。
 
@@ -345,8 +345,3 @@ aksresources
 - **クエリ構文の違い:**
   - `az graph query` CLI: テーブル名のみ（例: `containerserviceeventresources`）
   - Azure Monitor アラートルール: `arg("").` プレフィックスが必要（例: `arg("").containerserviceeventresources`）
-
-## 関連スキル
-
-- **bicep-api-version-updater**: BicepファイルのAPIバージョン更新
-- **bicep-what-if-analysis**: デプロイ前の影響分析とノイズ除去

--- a/.github/skills/bicep-api-version-updater/SKILL.md
+++ b/.github/skills/bicep-api-version-updater/SKILL.md
@@ -212,7 +212,3 @@ az bicep build --file infra/main.bicep 2>&1
 
 - 「特定のプレビュー機能を使いたい」（意図的なプレビュー使用）
 - 「APIバージョンを固定したい」（安定性優先）
-
-## 関連スキル
-
-- **bicep-what-if-analysis**: デプロイ前の影響分析とノイズ除去


### PR DESCRIPTION
## 概要

スキルファイルから不要な「関連スキル」セクションを削除。

## 理由

- Copilot CLI がタスクに応じてスキルを自動選択するため、ユーザーが関連性を意識する必要がない
- スキル追加・削除のたびに複数ファイルの更新が必要になり、メンテナンス負担が増える
- 各スキルの description で用途は十分説明されている

## 変更内容

- `aks-maintenance-checker/SKILL.md` から関連スキルセクションを削除
- `bicep-api-version-updater/SKILL.md` から関連スキルセクションを削除