### PR TITLE
fix: RSS取得をPython urllibに変更（Copilot CLI curl制限回避）

### DIFF
--- a/.github/workflows/aks-updates-analyzer.lock.yml
+++ b/.github/workflows/aks-updates-analyzer.lock.yml
@@ -23,7 +23,7 @@
 #
 # Weekly AKS updates analyzer that checks Azure Updates RSS and GitHub AKS changelog, then creates an issue with impact analysis for this repository.
 #
-# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"3469426fa6c5bf1471b97aeda84dad6f8c7193b5c973e11db6aa3e7bec120fe6","compiler_version":"v0.50.2"}
+# gh-aw-metadata: {"schema_version":"v1","frontmatter_hash":"ded3e4e47eaae5e63617d2bfb589b3bcabc82e47e8f8620cfd9020ad8ae5d6e8","compiler_version":"v0.50.2"}
 
 name: "AKS Updates 週次分析"
 "on":
@@ -655,7 +655,6 @@ jobs:
         # --allow-tool github
         # --allow-tool safeoutputs
         # --allow-tool shell(cat)
-        # --allow-tool shell(curl)
         # --allow-tool shell(date)
         # --allow-tool shell(echo)
         # --allow-tool shell(grep)
@@ -673,7 +672,7 @@ jobs:
         run: |
           set -o pipefail
           sudo -E awf --env-all --container-workdir "${GITHUB_WORKSPACE}" --allow-domains "*.githubusercontent.com,api.business.githubcopilot.com,api.enterprise.githubcopilot.com,api.github.com,api.githubcopilot.com,api.individual.githubcopilot.com,api.snapcraft.io,archive.ubuntu.com,azure.archive.ubuntu.com,codeload.github.com,crl.geotrust.com,crl.globalsign.com,crl.identrust.com,crl.sectigo.com,crl.thawte.com,crl.usertrust.com,crl.verisign.com,crl3.digicert.com,crl4.digicert.com,crls.ssl.com,github-cloud.githubusercontent.com,github-cloud.s3.amazonaws.com,github.com,github.githubassets.com,host.docker.internal,json-schema.org,json.schemastore.org,keyserver.ubuntu.com,lfs.github.com,objects.githubusercontent.com,ocsp.digicert.com,ocsp.geotrust.com,ocsp.globalsign.com,ocsp.identrust.com,ocsp.sectigo.com,ocsp.ssl.com,ocsp.thawte.com,ocsp.usertrust.com,ocsp.verisign.com,packagecloud.io,packages.cloud.google.com,packages.microsoft.com,ppa.launchpad.net,raw.githubusercontent.com,registry.npmjs.org,s.symcb.com,s.symcd.com,security.ubuntu.com,telemetry.enterprise.githubcopilot.com,ts-crl.ws.symantec.com,ts-ocsp.ws.symantec.com,www.microsoft.com" --log-level info --proxy-logs-dir /tmp/gh-aw/sandbox/firewall/logs --enable-host-access --image-tag 0.23.0 --skip-pull --enable-api-proxy \
-            -- /bin/bash -c '/usr/local/bin/copilot --add-dir /tmp/gh-aw/ --log-level all --log-dir /tmp/gh-aw/sandbox/agent/logs/ --add-dir "${GITHUB_WORKSPACE}" --disable-builtin-mcps --allow-tool github --allow-tool safeoutputs --allow-tool '\''shell(cat)'\'' --allow-tool '\''shell(curl)'\'' --allow-tool '\''shell(date)'\'' --allow-tool '\''shell(echo)'\'' --allow-tool '\''shell(grep)'\'' --allow-tool '\''shell(head)'\'' --allow-tool '\''shell(ls)'\'' --allow-tool '\''shell(pwd)'\'' --allow-tool '\''shell(python3)'\'' --allow-tool '\''shell(sort)'\'' --allow-tool '\''shell(tail)'\'' --allow-tool '\''shell(uniq)'\'' --allow-tool '\''shell(wc)'\'' --allow-tool '\''shell(yq)'\'' --allow-tool write --allow-all-paths --prompt "$(cat /tmp/gh-aw/aw-prompts/prompt.txt)"' 2>&1 | tee -a /tmp/gh-aw/agent-stdio.log
+            -- /bin/bash -c '/usr/local/bin/copilot --add-dir /tmp/gh-aw/ --log-level all --log-dir /tmp/gh-aw/sandbox/agent/logs/ --add-dir "${GITHUB_WORKSPACE}" --disable-builtin-mcps --allow-tool github --allow-tool safeoutputs --allow-tool '\''shell(cat)'\'' --allow-tool '\''shell(date)'\'' --allow-tool '\''shell(echo)'\'' --allow-tool '\''shell(grep)'\'' --allow-tool '\''shell(head)'\'' --allow-tool '\''shell(ls)'\'' --allow-tool '\''shell(pwd)'\'' --allow-tool '\''shell(python3)'\'' --allow-tool '\''shell(sort)'\'' --allow-tool '\''shell(tail)'\'' --allow-tool '\''shell(uniq)'\'' --allow-tool '\''shell(wc)'\'' --allow-tool '\''shell(yq)'\'' --allow-tool write --allow-all-paths --prompt "$(cat /tmp/gh-aw/aw-prompts/prompt.txt)"' 2>&1 | tee -a /tmp/gh-aw/agent-stdio.log
         env:
           COPILOT_AGENT_RUNNER_TYPE: STANDALONE
           COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}


### PR DESCRIPTION
## 問題

Copilot CLI のサンドボックス内で `curl` が `--allow-tool shell(curl)` に含まれているにもかかわらず "Permission denied" となり、Azure Updates RSS フィードを取得できない。

## 調査結果

- lock.yml の `--allow-tool` には `shell(curl)` が正しく含まれている
- ファイアウォール許可ドメインにも `www.microsoft.com` が含まれている
- しかし Copilot CLI がネットワークアクセスを伴う curl 呼び出しを拒否している
- 一方 `cat | python3` パターンでの外部アクセスは正常に動作

## 変更内容

1. **Step 1**: curl → Python urllib で RSS ダウンロード + パースを一体化したスクリプトに変更
2. **Step 2**: curl → Python urllib で GitHub AKS releases 取得に変更
3. **tools**: `["curl", "python3"]` → `["python3"]` に変更
4. **engine model**: `claude-opus-4.6` を明示的に指定（前回 PR #67 からの変更を含む）