### PR TITLE
fix: Azure Updates RSS のリンクが Issue に反映されない問題を修正

### DIFF
--- a/.github/workflows/aks-updates-analyzer.md
+++ b/.github/workflows/aks-updates-analyzer.md
@@ -82,6 +82,7 @@ for item in items:
                     "title": title.strip(),
                     "date": pub_date_str,
                     "link": link,
+                    "markdown_link": f"[{title.strip()}]({link})",
                     "desc": desc.strip()[:500]
                 })
         except Exception:
@@ -90,6 +91,8 @@ for item in items:
 print(json.dumps(aks_items, indent=2, ensure_ascii=False))
 PYEOF
 ```
+
+**注意**: 出力の `markdown_link` フィールドには `[タイトル](URL)` 形式のリンクが含まれています。Step 5 の Issue テーブルでは、このフィールドをそのまま「アップデート」列に使用してください。
 
 ## Step 2: GitHub AKS リリースノートを取得
 


### PR DESCRIPTION
## 概要

PR #71 の改善後もAzure Updates RSS 由来のアップデートにリンクが付かない問題を修正します。

## 原因

Step 1 の Python スクリプトは JSON に `link` フィールドを出力していますが、AI エージェントがテーブル作成時にこのフィールドを活用していませんでした。テンプレートでの指示だけでは不十分でした。

## 変更内容

- Step 1 の Python スクリプト出力に `markdown_link` フィールド（`[タイトル](URL)` 形式）を追加
- Step 1 の後に「`markdown_link` フィールドをテーブルの『アップデート』列にそのまま使用すること」という明示的な指示を追加

## 関連

- #70 (元の Issue)
- #71 (構造改善 PR)