### PR TITLE
docs: copilot-instructions.md をセッション履歴分析に基づき改善

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,6 +2,18 @@
 
 - 応答は日本語を使う。
 
+# プロジェクト概要
+
+AKS (Azure Kubernetes Service) 上で Chaos Engineering を実践するためのラボ環境。Azure Developer CLI (azd) でインフラとアプリを一括管理する。
+
+- **アプリ**: Python 3.13 + FastAPI (`src/`)
+- **IaC**: Bicep (`infra/`)
+- **K8s マニフェスト**: Kustomize (`k8s/`)
+- **パッケージ管理**: uv
+- **型チェッカー**: ty (Astral)
+- **リンター/フォーマッター**: ruff
+- **テスト**: pytest
+
 # ファイル管理とプロジェクト構造
 
 - ルートフォルダは必要最低限のファイル数に保ち、プロジェクト構造を明確に保つ。
@@ -9,6 +21,44 @@
 - 一時的なテストやデバッグ用のファイルを作成する場合は、ルートフォルダではなく`tmp`ディレクトリを作成し、その中で実行する。
 - 一時的ではない、その後も継続的にテストに使うべきファイルは、`tests`ディレクトリを作成し、その中に入れる。
 - 調査や検証が完了したら、不要になった一時ファイルは削除する。
+
+# Git ブランチ管理
+
+- **main ブランチに直接コミットしてはならない**。必ずフィーチャーブランチを作成し、PR 経由でマージする。
+- ブランチ命名例:
+  - 機能追加: `feature/<機能名>` または Spec Kit の `<番号>-<短縮名>`（例: `005-aks-nap-mode`）
+  - バグ修正: `fix/<修正内容>`
+  - メンテナンス: `chore/<内容>`
+
+# 破壊的操作の確認
+
+- `git reset`, `git push --force`, ブランチ削除、`azd down` など**取り消しが困難な操作**は、実行前にユーザーの明示的な許可を得ること。
+- ユーザーが「できるか」「可能か」と質問した場合は、**回答のみ行い、実行はしない**。実行の指示があるまで待つこと。
+
+# Python 開発
+
+- Python の実行には必ず `uv run` を使う（`python` を直接呼ばない）。
+- パッケージ追加は `uv add`、同期は `uv sync`。
+
+## 開発コマンド（`src/` ディレクトリ内で実行）
+
+```bash
+# 品質検証（リント + テスト + 型チェック）を一括実行
+cd src && make qa
+
+# 個別実行
+make test          # ユニットテスト
+make lint          # ruff リント（自動修正あり）
+make typecheck     # ty 型チェック
+make format        # ruff フォーマット
+make format-check  # フォーマット確認（変更なし）
+```
+
+## Bicep 検証
+
+```bash
+az bicep build --file infra/main.bicep
+```
 
 # ワークフロー
 
@@ -18,12 +68,3 @@
   - 依存パッケージのバージョン更新（セキュリティパッチ、バグ修正）
   - 軽微なドキュメント修正（誤字、リンク修正）
 - 詳細なルールは `.specify/memory/constitution.md` を参照
-
-## Active Technologies
-- Python 3.13 + uv (パッケージマネージャー)、FastAPI、uvicorn (002-uv-consolidation)
-- YAML (GitHub Actions) + Bash (テストスクリプト) + Azure CLI, Azure Developer CLI (azd), Bicep CLI, curl (003-platform-integration-test)
-- N/A（一時的なAzureリソース） (003-platform-integration-test)
-- Python 3.13 + ty (型チェッカー), ruff, pytest, FastAPI, uvicorn (004-mypy-to-pyright)
-
-## Recent Changes
-- 002-uv-consolidation: Added Python 3.13 + uv (パッケージマネージャー)、FastAPI、uvicorn


### PR DESCRIPTION
## 変更内容

セッション履歴（chronicle）の分析で発見したフリクションパターンに基づき、`.github/copilot-instructions.md` を改善。

### 追加・変更したセクション

- **プロジェクト概要**: 技術スタックの簡潔な記述（旧 Active Technologies/Recent Changes を置換）
- **Git ブランチ管理**: main 直接コミット禁止、ブランチ命名規則
- **破壊的操作の確認**: git reset/force push 等の実行前にユーザー許可を取るルール
- **Python 開発**: `uv run` 必須、`cd src && make qa` 等の開発コマンド一覧
- **Bicep 検証**: ビルドコマンド

### 根拠となったセッション履歴

| 問題 | セッション |
|------|-----------|
| main に直接コミット | `387d628a` (Update Library And API Versions) |
| uv を使わず python 直接実行 | `e34b20f8` (実装してください) |
| 確認なしに git reset 実行 | `ea7bc2e3` (mcp add) |
| 開発コマンド未記載による試行錯誤 | 複数セッション |