### PR TITLE
fix: normalize what-if unsupported resources

### DIFF
--- a/.github/skills/bicep-what-if-analysis/scripts/tests/test_what_if_analyzer.py
+++ b/.github/skills/bicep-what-if-analysis/scripts/tests/test_what_if_analyzer.py
@@ -19,7 +19,9 @@ from what_if_analyzer import (
     DisplayConfigLoader,
     NoisePatternLoader,
     evaluate_property_change,
+    extract_resource_changes,
     flatten_property_changes,
+    format_azd_style_output,
     get_reference_info,
     is_readonly_property,
     contains_arm_reference,
@@ -166,6 +168,107 @@ class TestFlattenPropertyChanges(unittest.TestCase):
         self.assertEqual(result[0]["path"], "properties.addressSpace.addressPrefixes")
 
 
+class TestExtractResourceChanges(unittest.TestCase):
+    """extract_resource_changes のテスト"""
+
+    def test_normalizes_unsupported_extension_resource(self) -> None:
+        """Unsupported な extensionResourceId を正規化する"""
+        what_if_result = {
+            "changes": [
+                {
+                    "changeType": "Unsupported",
+                    "resourceId": (
+                        "[extensionResourceId("
+                        "'/subscriptions/test-sub/resourceGroups/test-rg/"
+                        "providers/Microsoft.ContainerRegistry/registries/acrtest', "
+                        "'Microsoft.Authorization/roleAssignments', "
+                        "guid('/subscriptions/test-sub/resourceGroups/test-rg/"
+                        "providers/Microsoft.ContainerRegistry/registries/acrtest', "
+                        "reference('/subscriptions/test-sub/resourceGroups/test-rg/"
+                        "providers/Microsoft.ContainerService/managedClusters/akstest', "
+                        "'2025-06-02-preview').identityProfile.kubeletidentity.objectId, "
+                        "'AcrPull'))]"
+                    ),
+                }
+            ]
+        }
+
+        result = extract_resource_changes(what_if_result)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(
+            result[0]["resourceType"],
+            "Microsoft.ContainerRegistry/registries/providers/roleAssignments",
+        )
+        self.assertEqual(result[0]["resourceName"], "<dynamic>")
+        self.assertEqual(
+            result[0]["resourceId"],
+            "/subscriptions/test-sub/resourceGroups/test-rg/providers/"
+            "Microsoft.ContainerRegistry/registries/acrtest/providers/"
+            "Microsoft.Authorization/roleAssignments/<dynamic>",
+        )
+        self.assertEqual(
+            result[0]["originalResourceId"],
+            what_if_result["changes"][0]["resourceId"],
+        )
+
+    def test_uses_last_providers_segment_for_nested_extensions(self) -> None:
+        """ネストした拡張リソースでも最後の providers を使う"""
+        what_if_result = {
+            "changes": [
+                {
+                    "changeType": "Unsupported",
+                    "resourceId": (
+                        "[extensionResourceId("
+                        "'/subscriptions/test-sub/resourceGroups/test-rg/"
+                        "providers/Microsoft.ContainerService/managedClusters/"
+                        "akstest/providers/Microsoft.Chaos/targets/chaosmesh', "
+                        "'Microsoft.Authorization/roleAssignments', guid('scope', 'id'))]"
+                    ),
+                }
+            ]
+        }
+
+        result = extract_resource_changes(what_if_result)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(
+            result[0]["resourceType"],
+            "Microsoft.Chaos/targets/providers/roleAssignments",
+        )
+        self.assertEqual(
+            result[0]["resourceId"],
+            "/subscriptions/test-sub/resourceGroups/test-rg/providers/"
+            "Microsoft.ContainerService/managedClusters/akstest/providers/"
+            "Microsoft.Chaos/targets/chaosmesh/providers/"
+            "Microsoft.Authorization/roleAssignments/<dynamic>",
+        )
+
+    def test_keeps_existing_type_for_regular_extension_resource_ids(self) -> None:
+        """通常の拡張リソース ID は既存の型抽出を維持する"""
+        what_if_result = {
+            "changes": [
+                {
+                    "changeType": "Modify",
+                    "resourceId": (
+                        "/subscriptions/test-sub/resourceGroups/test-rg/providers/"
+                        "Microsoft.Network/virtualNetworks/vnettest/subnets/snet-app/"
+                        "providers/Microsoft.Authorization/roleAssignments/assignment1"
+                    ),
+                    "delta": [],
+                }
+            ]
+        }
+
+        result = extract_resource_changes(what_if_result)
+
+        self.assertEqual(len(result), 1)
+        self.assertEqual(
+            result[0]["resourceType"],
+            "Microsoft.Network/virtualNetworks/subnets/providers/roleAssignments",
+        )
+
+
 class TestNoisePatternLoader(unittest.TestCase):
     """NoisePatternLoader のテスト"""
 
@@ -258,6 +361,79 @@ class TestGetReferenceInfo(unittest.TestCase):
             bicep_definition={"status": "notDefined"},
         )
         self.assertIn("❓", result)
+
+
+class TestFormatAzdStyleOutput(unittest.TestCase):
+    """format_azd_style_output のテスト"""
+
+    def test_filters_known_acr_acrpull_unsupported(self) -> None:
+        """既知の ACR AcrPull Unsupported だけを非表示にする"""
+        output_data = {
+            "changes": [
+                {
+                    "operation": "Unsupported",
+                    "resourceId": (
+                        "/subscriptions/test-sub/resourceGroups/test-rg/providers/"
+                        "Microsoft.ContainerRegistry/registries/acrtest/providers/"
+                        "Microsoft.Authorization/roleAssignments/<dynamic>"
+                    ),
+                    "resourceType": (
+                        "Microsoft.ContainerRegistry/registries/providers/"
+                        "roleAssignments"
+                    ),
+                    "originalResourceId": (
+                        "[extensionResourceId("
+                        "'/subscriptions/test-sub/resourceGroups/test-rg/"
+                        "providers/Microsoft.ContainerRegistry/registries/acrtest', "
+                        "'Microsoft.Authorization/roleAssignments', "
+                        "guid('scope', reference('aks', '2025-06-02-preview')."
+                        "identityProfile.kubeletidentity.objectId, 'AcrPull'))]"
+                    ),
+                    "resourceName": "<dynamic>",
+                    "propertyChanges": [],
+                }
+            ]
+        }
+
+        result = format_azd_style_output(output_data)
+
+        self.assertEqual(result.strip(), "Resources:")
+
+    def test_keeps_other_acr_role_assignment_unsupported_visible(self) -> None:
+        """AcrPull kubelet 以外の ACR role assignment は表示する"""
+        output_data = {
+            "changes": [
+                {
+                    "operation": "Unsupported",
+                    "resourceId": (
+                        "/subscriptions/test-sub/resourceGroups/test-rg/providers/"
+                        "Microsoft.ContainerRegistry/registries/acrtest/providers/"
+                        "Microsoft.Authorization/roleAssignments/<dynamic>"
+                    ),
+                    "resourceType": (
+                        "Microsoft.ContainerRegistry/registries/providers/"
+                        "roleAssignments"
+                    ),
+                    "originalResourceId": (
+                        "[extensionResourceId("
+                        "'/subscriptions/test-sub/resourceGroups/test-rg/"
+                        "providers/Microsoft.ContainerRegistry/registries/acrtest', "
+                        "'Microsoft.Authorization/roleAssignments', "
+                        "guid('scope', 'pipeline-sp-id', 'AcrPush'))]"
+                    ),
+                    "resourceName": "<dynamic>",
+                    "propertyChanges": [],
+                }
+            ]
+        }
+
+        result = format_azd_style_output(output_data)
+
+        self.assertIn("Unsupported", result)
+        self.assertIn(
+            "Microsoft.ContainerRegistry/registries/providers/roleAssignments",
+            result,
+        )
 
 
 class TestPatternStats(unittest.TestCase):

--- a/.github/skills/bicep-what-if-analysis/scripts/what_if_analyzer.py
+++ b/.github/skills/bicep-what-if-analysis/scripts/what_if_analyzer.py
@@ -1158,6 +1158,102 @@ def flatten_property_changes(
     return changes
 
 
+def extract_resource_type_from_id(
+    resource_id: str, use_last_provider: bool = False
+) -> str:
+    """
+    Azure リソース ID からリソースタイプを抽出する。
+
+    Parameters:
+        resource_id: Azure リソース ID
+        use_last_provider: True の場合は最後の providers セグメントを基準にする
+
+    Returns:
+        リソースタイプ。抽出できない場合は空文字列。
+    """
+    if "providers/" not in resource_id:
+        return ""
+
+    find_provider = resource_id.rfind if use_last_provider else resource_id.find
+    provider_idx = find_provider("providers/") + len("providers/")
+    after_provider = resource_id[provider_idx:]
+    type_parts = after_provider.split("/")
+    if len(type_parts) < 2:
+        return ""
+
+    type_segments = [type_parts[0], type_parts[1]]
+    for i in range(3, len(type_parts), 2):
+        type_segments.append(type_parts[i])
+    return "/".join(type_segments)
+
+
+def normalize_unsupported_extension_resource(
+    resource_id: str,
+) -> tuple[str, str, str] | None:
+    """
+    extensionResourceId() 形式の Unsupported リソースを正規化する。
+
+    what-if は extensionResourceId() をそのまま返すことがあり、そのままでは
+    resourceType/resourceName の抽出が崩れる。親スコープの ARM ID と拡張
+    リソースタイプから、表示・フィルタリングに使える擬似リソース ID を作る。
+
+    Parameters:
+        resource_id: what-if が返した resourceId
+
+    Returns:
+        (normalized_resource_id, resource_type, resource_name)。
+        解析できない場合は None。
+    """
+    match = re.match(
+        r"^\[extensionResourceId\('(?P<scope>[^']+)',\s*"
+        r"'(?P<extension_type>[^']+)'",
+        resource_id,
+    )
+    if match is None:
+        return None
+
+    scope_id = match.group("scope")
+    extension_type = match.group("extension_type")
+    scope_type = extract_resource_type_from_id(scope_id, use_last_provider=True)
+    if not scope_type:
+        return None
+
+    extension_name = extension_type.split("/")[-1]
+    normalized_resource_id = (
+        f"{scope_id}/providers/{extension_type}/<dynamic>"
+    )
+    resource_type = f"{scope_type}/providers/{extension_name}"
+    resource_name = "<dynamic>"
+    return normalized_resource_id, resource_type, resource_name
+
+
+def is_known_acr_acrpull_unsupported(change: dict[str, Any]) -> bool:
+    """
+    既知の ACR AcrPull Unsupported ノイズかどうかを判定する。
+
+    Parameters:
+        change: extract_resource_changes() が返す変更情報
+
+    Returns:
+        既知ノイズの場合は True、それ以外は False。
+    """
+    if change.get("operation") != "Unsupported":
+        return False
+
+    resource_type = str(change.get("resourceType", "")).lower()
+    if resource_type != "microsoft.containerregistry/registries/providers/roleassignments":
+        return False
+
+    original_resource_id = str(change.get("originalResourceId", "")).lower()
+    required_terms = (
+        "microsoft.containerregistry/registries",
+        "microsoft.authorization/roleassignments",
+        "acrpull",
+        "kubeletidentity.objectid",
+    )
+    return all(term in original_resource_id for term in required_terms)
+
+
 def extract_resource_changes(
     what_if_result: dict[str, Any], bicep_dir: str = "./infra"
 ) -> list[dict[str, Any]]:
@@ -1168,27 +1264,18 @@ def extract_resource_changes(
         resource_id = change.get("resourceId", "")
         change_type = change.get("changeType", "Unknown")
 
-        # リソースタイプと名前を抽出
+        normalized_resource_id = resource_id
+        resource_type = extract_resource_type_from_id(resource_id)
         parts = resource_id.split("/")
         resource_name = parts[-1] if parts else ""
 
-        # providers/Microsoft.xxx/resourceType/name の形式からタイプを抽出
-        # 子リソースの場合も正しく抽出する（例: managedClusters/agentPools）
-        resource_type = ""
-        if "providers/" in resource_id:
-            provider_idx = resource_id.find("providers/") + len("providers/")
-            after_provider = resource_id[provider_idx:]
-            type_parts = after_provider.split("/")
-            # タイプセグメントのみを抽出（インデックス 0,1,3,5... = 名前をスキップ）
-            # 例: Microsoft.ContainerService/managedClusters/aks-main/agentPools/system
-            #     -> [Microsoft.ContainerService, managedClusters, aks-main, agentPools, system]
-            #     -> Microsoft.ContainerService/managedClusters/agentPools
-            if len(type_parts) >= 2:
-                type_segments = [type_parts[0], type_parts[1]]  # Provider/ParentType
-                # 子リソースタイプを追加（インデックス 3, 5, 7, ...）
-                for i in range(3, len(type_parts), 2):
-                    type_segments.append(type_parts[i])
-                resource_type = "/".join(type_segments)
+        normalized_unsupported = normalize_unsupported_extension_resource(resource_id)
+        if change_type == "Unsupported" and normalized_unsupported is not None:
+            (
+                normalized_resource_id,
+                resource_type,
+                resource_name,
+            ) = normalized_unsupported
 
         # プロパティ変更をフラット化（リソースタイプを渡す）
         delta = change.get("delta", [])
@@ -1197,7 +1284,8 @@ def extract_resource_changes(
         changes.append(
             {
                 "operation": change_type,
-                "resourceId": resource_id,
+                "resourceId": normalized_resource_id,
+                "originalResourceId": resource_id,
                 "resourceType": resource_type,
                 "resourceName": resource_name,
                 "propertyChanges": property_changes,
@@ -1366,7 +1454,7 @@ def get_resource_type_display_name(resource_type: str) -> str:
     return display_names.get(resource_type, resource_type)
 
 
-def is_main_resource(resource_type: str, resource_id: str) -> bool:
+def is_main_resource(change: dict[str, Any]) -> bool:
     """
     azd が表示する主要リソースかどうかを判定する。
 
@@ -1375,9 +1463,16 @@ def is_main_resource(resource_type: str, resource_id: str) -> bool:
 
     判定基準:
     1. リソース ID の最後の /providers/ セグメント以降で子リソースを判定
-       （拡張リソースの nested providers にも対応）
+        （拡張リソースの nested providers にも対応）
     2. display_config.json の filtered_resource_types でフィルタリング
+    3. 既知の Unsupported ノイズを個別ルールで除外
     """
+    resource_type = change.get("resourceType", "")
+    resource_id = change.get("resourceId", "")
+
+    if is_known_acr_acrpull_unsupported(change):
+        return False
+
     # リソース ID からスコープを判定
     # 子リソースは /providers/Type/name/childType/childName のような形式
     # 拡張リソースは .../providers/Microsoft.Xxx/.../providers/Microsoft.Yyy/... の形式
@@ -1432,7 +1527,7 @@ def format_azd_style_output(output_data: dict[str, Any]) -> str:
     main_resources = [
         c
         for c in output_data["changes"]
-        if is_main_resource(c["resourceType"], c.get("resourceId", ""))
+        if is_main_resource(c)
     ]
 
     # 最大幅を計算（整列用）


### PR DESCRIPTION
## Summary
- normalize ARM what-if Unsupported extensionResourceId output while preserving existing resource type parsing
- suppress only the known ACR AcrPull + kubelet identity Unsupported helper resource in azd-style output
- add regression tests for nested extension resources and targeted filtering

## Testing
- uv run python .github/skills/bicep-what-if-analysis/scripts/tests/test_what_if_analyzer.py
- uv run python .github/skills/bicep-what-if-analysis/scripts/what_if_analyzer.py