### PR TITLE
feat: AKS Automaticモードを再有効化

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,8 +63,6 @@
 
 [Azure Kubernetes Service \(AKS\) Automatic の概要 \- Azure Kubernetes Service \| Microsoft Learn](https://learn.microsoft.com/ja-jp/azure/aks/intro-aks-automatic)
 
-> **注意**: AKS Automatic モードは現在一時的に無効化されています。解決に時間を要する可能性が高いため、Base モードのみをご利用ください。詳細は [Issue #18](https://github.com/torumakabe/aks-chaos-lab/issues/18) をご参照ください。
-
 Base モードを選んだ場合は、Azure Kubernetes Fleet Manager が更新管理を担います。
 - Fleet フリート／メンバー／更新戦略／自動アップグレード プロファイルが `infra/modules/fleet.bicep` で自動作成されます。
 - 更新戦略は `beforeGates` に Approval ゲートを含み、手動承認が完了するまで Update Run は開始されません。

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -27,9 +27,10 @@ param aksApiSubnetPrefix string = '10.10.3.0/28'
 @description('Kubernetes version for AKS (x.y or x.y.z). Only used in Base mode; Automatic mode automatically selects and manages stable versions.')
 param kubernetesVersion string = '1.33'
 
-@description('AKS SKU mode - "Base" for traditional AKS with Cluster Autoscaler. Note: "Automatic" mode is temporarily disabled.')
+@description('AKS SKU mode - "Base" for traditional AKS with Cluster Autoscaler; "Automatic" for automated operations with Node Auto Provisioning.')
 @allowed([
   'Base'
+  'Automatic'
 ])
 param aksSkuName string = 'Base'
 


### PR DESCRIPTION
## 概要

azd経由のAKS Automaticデプロイが成功することを確認したため、Bicepパラメーターの制限を解除し、警告を削除します。

## 変更内容

- `infra/main.bicep`: `aksSkuName` の `@allowed` に `Automatic` を追加、`@description` を更新
- `README.md`: 一時的な無効化の警告ブロックを削除

## 検証

- azd 1.23.8 で `AKS_SKU_NAME=Automatic` を指定し、AKS クラスターのデプロイに成功（provisioningState: Succeeded, sku: Automatic）
- 上流 Issue [Azure/azure-dev#5851](https://github.com/Azure/azure-dev/issues/5851) の GetDeploymentSafeguardsFailed エラーは再現せず
- `az bicep build` および `make qa` パス

Closes #18