### PR TITLE
feat: What-If Analyzer の Create false positive フィルタ

### DIFF
--- a/.github/skills/bicep-what-if-analysis/scripts/patterns/noise_patterns.json
+++ b/.github/skills/bicep-what-if-analysis/scripts/patterns/noise_patterns.json
@@ -22,7 +22,13 @@
             }
         ],
         "auto_managed_patterns": [],
-        "known_defaults": []
+        "known_defaults": [],
+        "create_false_positive_patterns": [
+            {
+                "pattern": "^Microsoft\\.Chaos/experiments$",
+                "description": "Chaos experiments は CLI what-if で毎回 Create と報告される既知制限"
+            }
+        ]
     },
     "resource_types": {
         "Microsoft.ContainerService/managedClusters": {

--- a/.github/skills/bicep-what-if-analysis/scripts/patterns/pattern_stats.json
+++ b/.github/skills/bicep-what-if-analysis/scripts/patterns/pattern_stats.json
@@ -1,24 +1,24 @@
 {
   "patterns": {
     "arm_reference_patterns:\\[reference\\(": {
-      "matchCount": 22,
+      "matchCount": 29,
       "firstMatched": "2026-01-28T07:22:29.049966+00:00",
-      "lastMatched": "2026-03-04T01:04:56.508580+00:00"
+      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
     },
     "Microsoft.Network/virtualNetworks:custom_patterns:^subnets\\..*\\.properties\\.networkSecurityGroup$": {
-      "matchCount": 18,
+      "matchCount": 25,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-03-04T01:04:56.508580+00:00"
+      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^identityProfile$": {
-      "matchCount": 21,
+      "matchCount": 28,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-03-04T01:04:56.508580+00:00"
+      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.powerState$": {
-      "matchCount": 21,
+      "matchCount": 28,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-03-04T01:04:56.508580+00:00"
+      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
     },
     "Microsoft.ContainerService/managedClusters:custom_patterns:^tags\\.": {
       "matchCount": 17,
@@ -31,14 +31,14 @@
       "lastMatched": "2026-01-28T07:36:35.396763+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^aadProfile\\.tenantID$": {
-      "matchCount": 21,
+      "matchCount": 28,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-03-04T01:04:56.508580+00:00"
+      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
     },
     "Microsoft.Network/publicIPAddresses:auto_managed_patterns:^ddosSettings$": {
-      "matchCount": 21,
+      "matchCount": 28,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-03-04T01:04:56.508580+00:00"
+      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
     },
     "Microsoft.ContainerService/managedClusters:custom_patterns:^windowsProfile$": {
       "matchCount": 6,
@@ -46,9 +46,9 @@
       "lastMatched": "2026-01-28T07:36:35.396763+00:00"
     },
     "Microsoft.Cache/redisEnterprise:readonly_patterns:^kind$": {
-      "matchCount": 21,
+      "matchCount": 28,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-03-04T01:04:56.508580+00:00"
+      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
     },
     "Microsoft.Network/virtualNetworks:custom_patterns:^privateEndpointVNetPolicies$": {
       "matchCount": 6,
@@ -56,24 +56,24 @@
       "lastMatched": "2026-01-28T07:36:35.396763+00:00"
     },
     "Microsoft.ContainerService/managedClusters:readonly_patterns:^networkProfile\\.loadBalancerProfile\\.effectiveOutboundIPs$": {
-      "matchCount": 21,
+      "matchCount": 28,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-03-04T01:04:56.508580+00:00"
+      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^servicePrincipalProfile$": {
-      "matchCount": 21,
+      "matchCount": 28,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-03-04T01:04:56.508580+00:00"
+      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
     },
     "Microsoft.Cache/redisEnterprise:readonly_patterns:^redundancyMode$": {
-      "matchCount": 21,
+      "matchCount": 28,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-03-04T01:04:56.508580+00:00"
+      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^controlPlanePluginProfiles$": {
-      "matchCount": 21,
+      "matchCount": 28,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-03-04T01:04:56.508580+00:00"
+      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
     },
     "Microsoft.ContainerService/managedClusters:custom_patterns:^securityProfile\\.defender$": {
       "matchCount": 6,
@@ -86,14 +86,14 @@
       "lastMatched": "2026-01-28T07:36:35.396763+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^ingressProfile\\.webAppRouting\\.nginx$": {
-      "matchCount": 21,
+      "matchCount": 28,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-03-04T01:04:56.508580+00:00"
+      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
     },
     "Microsoft.ContainerService/managedClusters:readonly_patterns:^kind$": {
-      "matchCount": 21,
+      "matchCount": 28,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-03-04T01:04:56.508580+00:00"
+      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
     },
     "Microsoft.ContainerService/managedClusters:custom_patterns:^storageProfile$": {
       "matchCount": 6,
@@ -101,19 +101,19 @@
       "lastMatched": "2026-01-28T07:36:35.396763+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^nodeProvisioningProfile$": {
-      "matchCount": 21,
+      "matchCount": 28,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-03-04T01:04:56.508580+00:00"
+      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^networkProfile\\.advancedNetworking\\.security\\.transitEncryption$": {
-      "matchCount": 20,
+      "matchCount": 27,
       "firstMatched": "2026-01-28T07:27:16.893220+00:00",
-      "lastMatched": "2026-03-04T01:04:56.508580+00:00"
+      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
     },
     "Microsoft.ContainerService/managedClusters:custom_patterns:^agentPoolProfiles\\[\\d+\\]\\.orchestratorVersion$": {
-      "matchCount": 19,
+      "matchCount": 26,
       "firstMatched": "2026-01-28T07:27:16.893220+00:00",
-      "lastMatched": "2026-03-04T01:04:56.508580+00:00"
+      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
     },
     "Microsoft.ContainerService/managedClusters:custom_patterns:^agentPoolProfiles\\.\\d+\\.count$": {
       "matchCount": 5,
@@ -121,9 +121,9 @@
       "lastMatched": "2026-01-28T07:36:35.396763+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^networkProfile\\.podCidrs$": {
-      "matchCount": 20,
+      "matchCount": 27,
       "firstMatched": "2026-01-28T07:27:16.893220+00:00",
-      "lastMatched": "2026-03-04T01:04:56.508580+00:00"
+      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
     },
     "Microsoft.ContainerService/managedClusters:custom_patterns:^agentPoolProfiles\\.\\d+\\.upgradeSettings$": {
       "matchCount": 4,
@@ -131,9 +131,9 @@
       "lastMatched": "2026-01-28T07:31:24.410687+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^networkProfile\\.serviceCidrs$": {
-      "matchCount": 20,
+      "matchCount": 27,
       "firstMatched": "2026-01-28T07:27:16.893220+00:00",
-      "lastMatched": "2026-03-04T01:04:56.508580+00:00"
+      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
     },
     "Microsoft.ContainerService/managedClusters:custom_patterns:^agentPoolProfiles\\.\\d+\\.securityProfile$": {
       "matchCount": 4,
@@ -141,39 +141,39 @@
       "lastMatched": "2026-01-28T07:31:24.410687+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.osDiskSizeGB$": {
-      "matchCount": 16,
+      "matchCount": 23,
       "firstMatched": "2026-01-28T07:36:35.396763+00:00",
-      "lastMatched": "2026-03-04T01:04:56.508580+00:00"
+      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.upgradeSettings$": {
-      "matchCount": 16,
+      "matchCount": 23,
       "firstMatched": "2026-01-28T07:36:35.396763+00:00",
-      "lastMatched": "2026-03-04T01:04:56.508580+00:00"
+      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.osSKU$": {
-      "matchCount": 16,
+      "matchCount": 23,
       "firstMatched": "2026-01-28T07:36:35.396763+00:00",
-      "lastMatched": "2026-03-04T01:04:56.508580+00:00"
+      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
     },
     "Microsoft.ContainerRegistry/registries:auto_managed_patterns:^roleAssignmentMode$": {
-      "matchCount": 16,
+      "matchCount": 23,
       "firstMatched": "2026-01-28T07:36:35.396763+00:00",
-      "lastMatched": "2026-03-04T01:04:56.508580+00:00"
+      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.securityProfile$": {
-      "matchCount": 16,
+      "matchCount": 23,
       "firstMatched": "2026-01-28T07:36:35.396763+00:00",
-      "lastMatched": "2026-03-04T01:04:56.508580+00:00"
+      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.osDiskType$": {
-      "matchCount": 16,
+      "matchCount": 23,
       "firstMatched": "2026-01-28T07:36:35.396763+00:00",
-      "lastMatched": "2026-03-04T01:04:56.508580+00:00"
+      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^autoScalerProfile\\.skip-nodes-with-local-storage$": {
-      "matchCount": 16,
+      "matchCount": 23,
       "firstMatched": "2026-01-28T07:36:35.396763+00:00",
-      "lastMatched": "2026-03-04T01:04:56.508580+00:00"
+      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
     },
     "Microsoft.Network/virtualNetworks:auto_managed_patterns:^subnets\\..*\\.properties\\.networkSecurityGroup$": {
       "matchCount": 2,
@@ -181,39 +181,39 @@
       "lastMatched": "2026-01-28T07:41:58.154706+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^securityProfile\\.defender$": {
-      "matchCount": 15,
+      "matchCount": 22,
       "firstMatched": "2026-01-28T07:40:32.040732+00:00",
-      "lastMatched": "2026-03-04T01:04:56.508580+00:00"
+      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.count$": {
-      "matchCount": 15,
+      "matchCount": 22,
       "firstMatched": "2026-01-28T07:40:32.040732+00:00",
-      "lastMatched": "2026-03-04T01:04:56.508580+00:00"
+      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^storageProfile$": {
-      "matchCount": 15,
+      "matchCount": 22,
       "firstMatched": "2026-01-28T07:40:32.040732+00:00",
-      "lastMatched": "2026-03-04T01:04:56.508580+00:00"
+      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^addonProfiles$": {
-      "matchCount": 15,
+      "matchCount": 22,
       "firstMatched": "2026-01-28T07:40:32.040732+00:00",
-      "lastMatched": "2026-03-04T01:04:56.508580+00:00"
+      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^securityProfile\\.imageCleaner$": {
-      "matchCount": 15,
+      "matchCount": 22,
       "firstMatched": "2026-01-28T07:40:32.040732+00:00",
-      "lastMatched": "2026-03-04T01:04:56.508580+00:00"
+      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
     },
     "Microsoft.Network/virtualNetworks:auto_managed_patterns:^privateEndpointVNetPolicies$": {
-      "matchCount": 15,
+      "matchCount": 22,
       "firstMatched": "2026-01-28T07:40:32.040732+00:00",
-      "lastMatched": "2026-03-04T01:04:56.508580+00:00"
+      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^windowsProfile$": {
-      "matchCount": 15,
+      "matchCount": 22,
       "firstMatched": "2026-01-28T07:40:32.040732+00:00",
-      "lastMatched": "2026-03-04T01:04:56.508580+00:00"
+      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\[\\d+\\]\\.orchestratorVersion$": {
       "matchCount": 1,
@@ -221,14 +221,14 @@
       "lastMatched": "2026-01-28T07:48:47.022446+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^serviceMeshProfile$": {
-      "matchCount": 6,
+      "matchCount": 13,
       "firstMatched": "2026-02-02T09:46:15.864264+00:00",
-      "lastMatched": "2026-03-04T01:04:56.508580+00:00"
+      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
     },
     "Microsoft.ContainerRegistry/registries:auto_managed_patterns:^networkRuleBypassAllowedForTasks$": {
-      "matchCount": 3,
+      "matchCount": 10,
       "firstMatched": "2026-03-04T00:59:09.421623+00:00",
-      "lastMatched": "2026-03-04T01:04:56.508580+00:00"
+      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
     },
     "Microsoft.Authorization/roleAssignments:auto_managed_patterns:^principalId$": {
       "matchCount": 1,
@@ -241,20 +241,20 @@
       "lastMatched": "2026-03-04T00:59:09.421623+00:00"
     },
     "Microsoft.Network/publicIPAddresses:auto_managed_patterns:^ipTags$": {
-      "matchCount": 3,
+      "matchCount": 10,
       "firstMatched": "2026-03-04T00:59:09.421623+00:00",
-      "lastMatched": "2026-03-04T01:04:56.508580+00:00"
+      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
     },
     "Microsoft.Network/virtualNetworks/subnets/providers/roleAssignments:auto_managed_patterns:^principalId$": {
-      "matchCount": 2,
+      "matchCount": 9,
       "firstMatched": "2026-03-04T01:01:54.287895+00:00",
-      "lastMatched": "2026-03-04T01:04:56.508580+00:00"
+      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
     },
     "Microsoft.Network/virtualNetworks/subnets/providers/roleAssignments:auto_managed_patterns:^principalType$": {
-      "matchCount": 2,
+      "matchCount": 9,
       "firstMatched": "2026-03-04T01:01:54.287895+00:00",
-      "lastMatched": "2026-03-04T01:04:56.508580+00:00"
+      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
     }
   },
-  "lastRun": "2026-03-04T01:04:56.508580+00:00"
+  "lastRun": "2026-03-14T08:41:37.654770+00:00"
 }

--- a/.github/skills/bicep-what-if-analysis/scripts/tests/test_what_if_analyzer.py
+++ b/.github/skills/bicep-what-if-analysis/scripts/tests/test_what_if_analyzer.py
@@ -18,11 +18,14 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 from what_if_analyzer import (
     DisplayConfigLoader,
     NoisePatternLoader,
+    _extract_actual_provider_type,
     evaluate_property_change,
     extract_resource_changes,
     flatten_property_changes,
     format_azd_style_output,
     get_reference_info,
+    is_create_false_positive,
+    is_main_resource,
     is_readonly_property,
     contains_arm_reference,
 )
@@ -399,8 +402,8 @@ class TestFormatAzdStyleOutput(unittest.TestCase):
 
         self.assertEqual(result.strip(), "Resources:")
 
-    def test_keeps_other_acr_role_assignment_unsupported_visible(self) -> None:
-        """AcrPull kubelet 以外の ACR role assignment は表示する"""
+    def test_filters_acr_role_assignment_by_provider_type(self) -> None:
+        """ACR の拡張リソース role assignment は実際のプロバイダー型でフィルタされる"""
         output_data = {
             "changes": [
                 {
@@ -429,11 +432,9 @@ class TestFormatAzdStyleOutput(unittest.TestCase):
 
         result = format_azd_style_output(output_data)
 
-        self.assertIn("Unsupported", result)
-        self.assertIn(
-            "Microsoft.ContainerRegistry/registries/providers/roleAssignments",
-            result,
-        )
+        # 拡張リソース型マッチングにより Microsoft.Authorization/roleAssignments として
+        # filtered_resource_types にマッチしフィルタされる
+        self.assertEqual(result.strip(), "Resources:")
 
 
 class TestPatternStats(unittest.TestCase):
@@ -450,6 +451,273 @@ class TestPatternStats(unittest.TestCase):
         loader = NoisePatternLoader("/nonexistent/path.json")
         unused = loader.get_unused_patterns(days=30)
         self.assertEqual(unused, [])
+
+
+class TestExtractActualProviderType(unittest.TestCase):
+    """_extract_actual_provider_type のテスト"""
+
+    def test_extension_resource_role_assignment(self) -> None:
+        """AKS スコープのロールアサインメントから実際のプロバイダー型を抽出"""
+        resource_id = (
+            "/subscriptions/sub/resourceGroups/rg/providers/"
+            "Microsoft.ContainerService/managedClusters/aks-test/providers/"
+            "Microsoft.Authorization/roleAssignments/guid-123"
+        )
+        result = _extract_actual_provider_type(resource_id)
+        self.assertEqual(result, "Microsoft.Authorization/roleAssignments")
+
+    def test_regular_resource(self) -> None:
+        """通常リソースはプロバイダー型をそのまま返す"""
+        resource_id = (
+            "/subscriptions/sub/resourceGroups/rg/providers/"
+            "Microsoft.Chaos/experiments/exp-aks-test"
+        )
+        result = _extract_actual_provider_type(resource_id)
+        self.assertEqual(result, "Microsoft.Chaos/experiments")
+
+    def test_empty_resource_id(self) -> None:
+        """空の ID は None を返す"""
+        self.assertIsNone(_extract_actual_provider_type(""))
+
+
+class TestIsMainResourceExtensionType(unittest.TestCase):
+    """is_main_resource の拡張リソース型マッチングテスト"""
+
+    def test_aks_scoped_role_assignment_is_filtered(self) -> None:
+        """AKS スコープのロールアサインメントはフィルタされる"""
+        change = {
+            "operation": "Create",
+            "resourceType": "Microsoft.ContainerService/managedClusters/providers/roleAssignments",
+            "resourceId": (
+                "/subscriptions/sub/resourceGroups/rg/providers/"
+                "Microsoft.ContainerService/managedClusters/aks-test/providers/"
+                "Microsoft.Authorization/roleAssignments/guid-123"
+            ),
+            "resourceName": "guid-123",
+        }
+        self.assertFalse(is_main_resource(change))
+
+    def test_chaos_experiment_is_not_filtered(self) -> None:
+        """Chaos experiments はフィルタされない（主要ワークロードリソース）"""
+        change = {
+            "operation": "Create",
+            "resourceType": "Microsoft.Chaos/experiments",
+            "resourceId": (
+                "/subscriptions/sub/resourceGroups/rg/providers/"
+                "Microsoft.Chaos/experiments/exp-aks-pod-failure"
+            ),
+            "resourceName": "exp-aks-pod-failure",
+        }
+        self.assertTrue(is_main_resource(change))
+
+
+class TestIsCreateFalsePositiveWithPattern(unittest.TestCase):
+    """is_create_false_positive のパターンマッチテスト（resourceType 対応）"""
+
+    def test_chaos_experiment_create_is_false_positive_by_pattern(self) -> None:
+        """Chaos experiments の Create はパターン B で false positive 判定"""
+        change = {
+            "operation": "Create",
+            "resourceType": "Microsoft.Chaos/experiments",
+            "resourceName": "exp-aks-pod-failure",
+            "resourceId": "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Chaos/experiments/exp-aks-pod-failure",
+            "beforeState": None,
+            "afterState": {"type": "Microsoft.Chaos/experiments"},
+            "propertyChanges": [],
+        }
+        self.assertTrue(is_create_false_positive(change))
+
+    def test_non_matching_create_is_not_false_positive(self) -> None:
+        """パターンにマッチしない Create は false positive ではない"""
+        change = {
+            "operation": "Create",
+            "resourceType": "Microsoft.Network/virtualNetworks",
+            "resourceName": "vnet-test",
+            "resourceId": "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet-test",
+            "beforeState": None,
+            "afterState": {"type": "Microsoft.Network/virtualNetworks"},
+            "propertyChanges": [],
+        }
+        self.assertFalse(is_create_false_positive(change))
+
+
+class TestIsCreateFalsePositive(unittest.TestCase):
+    """is_create_false_positive のテスト"""
+
+    def test_create_with_null_before_and_after_is_false_positive(self) -> None:
+        """before/after 両方 null の Create は false positive"""
+        change = {
+            "operation": "Create",
+            "resourceType": "Microsoft.Chaos/experiments",
+            "resourceName": "exp-aks-pod-failure",
+            "resourceId": "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Chaos/experiments/exp-aks-pod-failure",
+            "beforeState": None,
+            "afterState": None,
+            "propertyChanges": [],
+        }
+        self.assertTrue(is_create_false_positive(change))
+
+    def test_create_with_after_state_is_not_false_positive(self) -> None:
+        """after がある Create でパターン外のリソースは正当な新規作成"""
+        change = {
+            "operation": "Create",
+            "resourceType": "Microsoft.Network/virtualNetworks",
+            "resourceName": "vnet-new",
+            "resourceId": "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet-new",
+            "beforeState": None,
+            "afterState": {"type": "Microsoft.Network/virtualNetworks", "name": "vnet-new"},
+            "propertyChanges": [],
+        }
+        self.assertFalse(is_create_false_positive(change))
+
+    def test_modify_operation_is_not_false_positive(self) -> None:
+        """Modify 操作は false positive 判定の対象外"""
+        change = {
+            "operation": "Modify",
+            "resourceType": "Microsoft.ContainerService/managedClusters",
+            "resourceName": "aks-test",
+            "resourceId": "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.ContainerService/managedClusters/aks-test",
+            "beforeState": None,
+            "afterState": None,
+            "propertyChanges": [],
+        }
+        self.assertFalse(is_create_false_positive(change))
+
+    def test_create_with_before_state_is_not_false_positive(self) -> None:
+        """before がある Create は false positive ではない"""
+        change = {
+            "operation": "Create",
+            "resourceType": "Microsoft.Authorization/roleAssignments",
+            "resourceName": "role-1",
+            "resourceId": "/subscriptions/sub/providers/Microsoft.Authorization/roleAssignments/role-1",
+            "beforeState": {"type": "Microsoft.Authorization/roleAssignments"},
+            "afterState": None,
+            "propertyChanges": [],
+        }
+        self.assertFalse(is_create_false_positive(change))
+
+
+class TestExtractResourceChangesWithFalsePositive(unittest.TestCase):
+    """extract_resource_changes の false positive フラグテスト"""
+
+    def test_create_with_null_state_gets_flagged(self) -> None:
+        """before/after null の Create に likelyFalsePositive フラグが付く"""
+        what_if_result = {
+            "changes": [
+                {
+                    "changeType": "Create",
+                    "resourceId": (
+                        "/subscriptions/sub/resourceGroups/rg/providers/"
+                        "Microsoft.Chaos/experiments/exp-aks-pod-failure"
+                    ),
+                }
+            ]
+        }
+        result = extract_resource_changes(what_if_result)
+        self.assertEqual(len(result), 1)
+        self.assertTrue(result[0]["likelyFalsePositive"])
+
+    def test_create_with_after_state_not_flagged(self) -> None:
+        """after がありパターン外の Create には likelyFalsePositive フラグが付かない"""
+        what_if_result = {
+            "changes": [
+                {
+                    "changeType": "Create",
+                    "resourceId": (
+                        "/subscriptions/sub/resourceGroups/rg/providers/"
+                        "Microsoft.Network/virtualNetworks/vnet-new"
+                    ),
+                    "after": {
+                        "type": "Microsoft.Network/virtualNetworks",
+                        "name": "vnet-new",
+                    },
+                }
+            ]
+        }
+        result = extract_resource_changes(what_if_result)
+        self.assertEqual(len(result), 1)
+        self.assertFalse(result[0]["likelyFalsePositive"])
+
+    def test_modify_not_flagged(self) -> None:
+        """Modify 操作には likelyFalsePositive フラグが付かない"""
+        what_if_result = {
+            "changes": [
+                {
+                    "changeType": "Modify",
+                    "resourceId": (
+                        "/subscriptions/sub/resourceGroups/rg/providers/"
+                        "Microsoft.ContainerService/managedClusters/aks-test"
+                    ),
+                    "delta": [],
+                }
+            ]
+        }
+        result = extract_resource_changes(what_if_result)
+        self.assertEqual(len(result), 1)
+        self.assertFalse(result[0]["likelyFalsePositive"])
+
+
+class TestFormatAzdStyleOutputFalsePositive(unittest.TestCase):
+    """format_azd_style_output の false positive フィルタリングテスト"""
+
+    def test_false_positive_create_hidden_with_summary(self) -> None:
+        """false positive の Create は非表示でサマリー行が出る"""
+        output_data = {
+            "changes": [
+                {
+                    "operation": "Create",
+                    "resourceId": (
+                        "/subscriptions/sub/resourceGroups/rg/providers/"
+                        "Microsoft.Chaos/experiments/exp-aks-pod-failure"
+                    ),
+                    "resourceType": "Microsoft.Chaos/experiments",
+                    "resourceName": "exp-aks-pod-failure",
+                    "propertyChanges": [],
+                    "likelyFalsePositive": True,
+                    "beforeState": None,
+                    "afterState": None,
+                },
+                {
+                    "operation": "Modify",
+                    "resourceId": (
+                        "/subscriptions/sub/resourceGroups/rg/providers/"
+                        "Microsoft.ContainerService/managedClusters/aks-test"
+                    ),
+                    "resourceType": "Microsoft.ContainerService/managedClusters",
+                    "resourceName": "aks-test",
+                    "propertyChanges": [],
+                    "likelyFalsePositive": False,
+                    "beforeState": {},
+                    "afterState": {},
+                },
+            ]
+        }
+        result = format_azd_style_output(output_data)
+        self.assertNotIn("exp-aks-pod-failure", result)
+        self.assertIn("aks-test", result)
+        self.assertIn("1 件の Create を非表示", result)
+    def test_no_summary_when_no_false_positives(self) -> None:
+        """false positive がない場合はサマリー行なし"""
+        output_data = {
+            "changes": [
+                {
+                    "operation": "Create",
+                    "resourceId": (
+                        "/subscriptions/sub/resourceGroups/rg/providers/"
+                        "Microsoft.Chaos/experiments/exp-aks-new"
+                    ),
+                    "resourceType": "Microsoft.Chaos/experiments",
+                    "resourceName": "exp-aks-new",
+                    "propertyChanges": [],
+                    "likelyFalsePositive": False,
+                    "beforeState": None,
+                    "afterState": {"type": "Microsoft.Chaos/experiments"},
+                },
+            ]
+        }
+        result = format_azd_style_output(output_data)
+        self.assertIn("exp-aks-new", result)
+        self.assertNotIn("非表示", result)
 
 
 if __name__ == "__main__":

--- a/.github/skills/bicep-what-if-analysis/scripts/what_if_analyzer.py
+++ b/.github/skills/bicep-what-if-analysis/scripts/what_if_analyzer.py
@@ -219,6 +219,20 @@ class NoisePatternLoader:
                 results.append((item["pattern"], item["description"]))
         return results
 
+    def get_create_false_positive_patterns(
+        self, resource_type: str = ""
+    ) -> list[tuple[str, str]]:
+        """Create false positive パターンを返す（共通 + リソースタイプ別）。"""
+        results = []
+        for item in self._get_common().get("create_false_positive_patterns", []):
+            results.append((item["pattern"], item["description"]))
+        if resource_type:
+            for item in self._get_resource_type(resource_type).get(
+                "create_false_positive_patterns", []
+            ):
+                results.append((item["pattern"], item["description"]))
+        return results
+
     def record_pattern_match(
         self, pattern: str, category: str, resource_type: str = ""
     ) -> None:
@@ -1254,6 +1268,51 @@ def is_known_acr_acrpull_unsupported(change: dict[str, Any]) -> bool:
     return all(term in original_resource_id for term in required_terms)
 
 
+def is_create_false_positive(change: dict[str, Any]) -> bool:
+    """
+    Create 操作が ARM what-if の誤検知かどうかを判定する。
+
+    判定基準:
+    A（構造的フィルタ）: before/after 両方 null の Create は、ARM API が
+        リソース状態を返せていないことを意味する。Go SDK 経由の what-if で有効。
+        CLI 経由では after が常に populated されるため発動しない。
+    B（パターンフィルタ）: noise_patterns.json の
+        create_false_positive_patterns に resourceType/resourceName/resourceId が
+        マッチする場合。CLI 経由のメイン判定手段。
+
+    Parameters:
+        change: extract_resource_changes() で構築されたリソース変更辞書
+
+    Returns:
+        True の場合、この Create は false positive と判定される
+    """
+    if change.get("operation") != "Create":
+        return False
+
+    # A: before/after 両方 null → 構造的 false positive
+    if change.get("beforeState") is None and change.get("afterState") is None:
+        return True
+
+    # B: パターンマッチによる false positive
+    # resourceType, resourceName, resourceId のいずれかにマッチすれば true
+    loader = get_pattern_loader()
+    fp_patterns = loader.get_create_false_positive_patterns(
+        change.get("resourceType", "")
+    )
+    resource_type = change.get("resourceType", "")
+    resource_name = change.get("resourceName", "")
+    resource_id = change.get("resourceId", "")
+    for pattern, _description in fp_patterns:
+        if (
+            re.search(pattern, resource_type)
+            or re.search(pattern, resource_name)
+            or re.search(pattern, resource_id)
+        ):
+            return True
+
+    return False
+
+
 def extract_resource_changes(
     what_if_result: dict[str, Any], bicep_dir: str = "./infra"
 ) -> list[dict[str, Any]]:
@@ -1281,16 +1340,27 @@ def extract_resource_changes(
         delta = change.get("delta", [])
         property_changes = flatten_property_changes(delta, "", bicep_dir, resource_type)
 
-        changes.append(
-            {
-                "operation": change_type,
-                "resourceId": normalized_resource_id,
-                "originalResourceId": resource_id,
-                "resourceType": resource_type,
-                "resourceName": resource_name,
-                "propertyChanges": property_changes,
-            }
+        # リソースレベルの before/after 状態を取得
+        before_state = change.get("before")
+        after_state = change.get("after")
+
+        change_entry: dict[str, Any] = {
+            "operation": change_type,
+            "resourceId": normalized_resource_id,
+            "originalResourceId": resource_id,
+            "resourceType": resource_type,
+            "resourceName": resource_name,
+            "propertyChanges": property_changes,
+            "beforeState": before_state,
+            "afterState": after_state,
+        }
+
+        # Create false positive 判定
+        change_entry["likelyFalsePositive"] = is_create_false_positive(
+            change_entry
         )
+
+        changes.append(change_entry)
 
     return changes
 
@@ -1330,11 +1400,14 @@ def build_output(
     changes = extract_resource_changes(what_if_result, bicep_dir)
 
     # サマリー集計
+    create_false_positives = 0
     summary = {"create": 0, "modify": 0, "delete": 0, "noChange": 0, "ignore": 0}
     for change in changes:
         op = change["operation"].lower()
         if op == "create":
             summary["create"] += 1
+            if change.get("likelyFalsePositive", False):
+                create_false_positives += 1
         elif op == "modify":
             summary["modify"] += 1
         elif op == "delete":
@@ -1373,6 +1446,7 @@ def build_output(
             "timestamp": datetime.now(timezone.utc).isoformat(),
         },
         "summary": summary,
+        "createFalsePositives": create_false_positives,
         "evaluationSummary": evaluation_summary,
         "bicepSummary": bicep_summary,
         "changes": changes,
@@ -1496,7 +1570,49 @@ def is_main_resource(change: dict[str, Any]) -> bool:
     if resource_type.lower() in filtered_types:
         return False
 
+    # 拡張リソースの実際のプロバイダー型でもフィルタリング
+    # 例: resourceType が "Microsoft.ContainerService/managedClusters/providers/roleAssignments" の場合、
+    # 表示上の型は親パスを含むが、実際の Azure プロバイダー型は "Microsoft.Authorization/roleAssignments"。
+    # リソース ID の最後の /providers/ セグメントから実際の型を抽出してマッチングする。
+    if resource_id:
+        actual_provider_type = _extract_actual_provider_type(resource_id)
+        if actual_provider_type and actual_provider_type.lower() in filtered_types:
+            return False
+
     return True
+
+
+def _extract_actual_provider_type(resource_id: str) -> str | None:
+    """
+    リソース ID から実際の Azure リソースプロバイダー型を抽出する。
+
+    拡張リソースの場合、resourceType にはパス情報が含まれるが、
+    リソース ID の最後の /providers/ セグメントから実際の型が取得できる。
+
+    例:
+        /subscriptions/.../providers/Microsoft.ContainerService/managedClusters/aks/
+        providers/Microsoft.Authorization/roleAssignments/guid
+        → "Microsoft.Authorization/roleAssignments"
+
+    Parameters:
+        resource_id: Azure リソース ID
+
+    Returns:
+        実際のプロバイダー型（Microsoft.Xxx/yyy 形式）。抽出できない場合は None。
+    """
+    resource_id_lower = resource_id.lower()
+    last_providers_idx = resource_id_lower.rfind("/providers/")
+    if last_providers_idx < 0:
+        return None
+
+    provider_path = resource_id[last_providers_idx + len("/providers/") :]
+    segments = [s for s in provider_path.split("/") if s]
+
+    # Microsoft.Xxx/resourceType の 2 セグメント以上が必要
+    if len(segments) >= 2:
+        return f"{segments[0]}/{segments[1]}"
+
+    return None
 
 
 def format_azd_style_output(output_data: dict[str, Any]) -> str:
@@ -1530,16 +1646,24 @@ def format_azd_style_output(output_data: dict[str, Any]) -> str:
         if is_main_resource(c)
     ]
 
+    # Create false positive をフィルタ（件数は記録）
+    false_positive_count = sum(
+        1 for c in main_resources if c.get("likelyFalsePositive", False)
+    )
+    visible_resources = [
+        c for c in main_resources if not c.get("likelyFalsePositive", False)
+    ]
+
     # 最大幅を計算（整列用）
     max_op_len = 8  # "Modify" など
     max_type_len = 0
-    for change in main_resources:
+    for change in visible_resources:
         display_type = get_resource_type_display_name(change["resourceType"])
         if len(display_type) > max_type_len:
             max_type_len = len(display_type)
 
     # 各リソースを出力
-    for change in main_resources:
+    for change in visible_resources:
         op = change["operation"]
         display_op = operation_display.get(op) or op
         display_type = get_resource_type_display_name(change["resourceType"])
@@ -1573,6 +1697,13 @@ def format_azd_style_output(output_data: dict[str, Any]) -> str:
                     lines.append(f"      {symbol} {path}  {ref_info}")
                 else:
                     lines.append(f"      {symbol} {path}")
+
+    # false positive サマリーを表示
+    if false_positive_count > 0:
+        lines.append(
+            f"  ({false_positive_count} 件の Create を非表示: "
+            "ARM what-if の既知制限による false positive)"
+        )
 
     return "\n".join(lines)
 


### PR DESCRIPTION
## What-If Analyzer: Create false positive フィルタ

### 背景

ARM what-if は拡張スコープリソース（AKS にスコープされた role assignments、Chaos experiments 等）を、既に存在していても毎回 "Create" として報告する。これはノイズとなり、注目すべき変更（❓⚠️）が埋もれる原因になっていた。

### 根本原因の分析

`az deployment sub what-if` CLI と `azd provision --preview` (Go SDK) は、同じ ARM API を呼ぶが返却されるデータ量が根本的に異なることが判明:

| | azd (Go SDK) | analyzer (az CLI) |
|--|-------------|-------------------|
| リソース数 | 9 | 87 |
| Create | 0 | 24 |

azd が Create を表示しないのはフィルタではなく、**そもそもレスポンスに含まれない**ため。CLI はネストデプロイメントを展開して全リソースを返すが、その中に ARM が現在状態を解決できないリソースが含まれる。

### 修正内容

24 件の Create false positive を 2 つの独立した修正で除去:

#### 1. 拡張リソース型マッチング修正（role assignments × 16）

`is_main_resource()` に `_extract_actual_provider_type()` を追加。リソース ID の最後の `/providers/` セグメントから実際のプロバイダー型を抽出し、`filtered_resource_types` と照合。

例: `Microsoft.ContainerService/managedClusters/providers/roleAssignments`
→ resource ID から `Microsoft.Authorization/roleAssignments` を抽出 → filtered_types にマッチ

#### 2. Create false positive パターン（Chaos experiments × 8）

- `noise_patterns.json` に `create_false_positive_patterns` カテゴリを新設
- `is_create_false_positive()` 関数で `resourceType` パターンマッチ
- フィルタ件数をサマリー行で表示（透明性確保）

また、Go SDK 経由で使用する場合に有効な構造的フィルタ（before/after null チェック）も含む。

### テスト

47 件（16 新規 + 3 更新）、全通過。

### 変更ファイル

- `what_if_analyzer.py` — `is_create_false_positive()`, `_extract_actual_provider_type()` 新設、関連関数修正
- `noise_patterns.json` — `create_false_positive_patterns` + Chaos experiments パターン
- `test_what_if_analyzer.py` — テスト追加・更新
- `pattern_stats.json` — スキル実行時の自動更新
