### PR TITLE
chore: what-if ノイズパターンに kubernetesVersion を追加

### DIFF
--- a/.github/skills/bicep-what-if-analysis/scripts/patterns/noise_patterns.json
+++ b/.github/skills/bicep-what-if-analysis/scripts/patterns/noise_patterns.json
@@ -63,6 +63,7 @@
                 {"pattern": "^serviceMeshProfile$", "description": "サービスメッシュプロファイルは Bicep 未定義時に Azure が Disabled をデフォルト設定"}
             ],
             "custom_patterns": [
+                {"pattern": "^kubernetesVersion$", "description": "K8s バージョン要確認（マイナーまで一致ならOK、パッチは AKS 自動適用）"},
                 {"pattern": "^agentPoolProfiles\\.\\d+\\.orchestratorVersion$", "description": "K8s バージョン要確認（マイナーまで一致ならOK、パッチは AKS 自動適用）"},
                 {"pattern": "^agentPoolProfiles\\[\\d+\\]\\.orchestratorVersion$", "description": "K8s バージョン要確認（マイナーまで一致ならOK、パッチは AKS 自動適用）"}
             ],

--- a/.github/skills/bicep-what-if-analysis/scripts/patterns/pattern_stats.json
+++ b/.github/skills/bicep-what-if-analysis/scripts/patterns/pattern_stats.json
@@ -1,24 +1,24 @@
 {
   "patterns": {
     "arm_reference_patterns:\\[reference\\(": {
-      "matchCount": 29,
+      "matchCount": 32,
       "firstMatched": "2026-01-28T07:22:29.049966+00:00",
-      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
+      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
     },
     "Microsoft.Network/virtualNetworks:custom_patterns:^subnets\\..*\\.properties\\.networkSecurityGroup$": {
-      "matchCount": 25,
+      "matchCount": 27,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
+      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^identityProfile$": {
-      "matchCount": 28,
+      "matchCount": 30,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
+      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.powerState$": {
-      "matchCount": 28,
+      "matchCount": 30,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
+      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
     },
     "Microsoft.ContainerService/managedClusters:custom_patterns:^tags\\.": {
       "matchCount": 17,
@@ -31,14 +31,14 @@
       "lastMatched": "2026-01-28T07:36:35.396763+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^aadProfile\\.tenantID$": {
-      "matchCount": 28,
+      "matchCount": 30,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
+      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
     },
     "Microsoft.Network/publicIPAddresses:auto_managed_patterns:^ddosSettings$": {
-      "matchCount": 28,
+      "matchCount": 30,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
+      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
     },
     "Microsoft.ContainerService/managedClusters:custom_patterns:^windowsProfile$": {
       "matchCount": 6,
@@ -46,9 +46,9 @@
       "lastMatched": "2026-01-28T07:36:35.396763+00:00"
     },
     "Microsoft.Cache/redisEnterprise:readonly_patterns:^kind$": {
-      "matchCount": 28,
+      "matchCount": 30,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
+      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
     },
     "Microsoft.Network/virtualNetworks:custom_patterns:^privateEndpointVNetPolicies$": {
       "matchCount": 6,
@@ -56,24 +56,24 @@
       "lastMatched": "2026-01-28T07:36:35.396763+00:00"
     },
     "Microsoft.ContainerService/managedClusters:readonly_patterns:^networkProfile\\.loadBalancerProfile\\.effectiveOutboundIPs$": {
-      "matchCount": 28,
+      "matchCount": 30,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
+      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^servicePrincipalProfile$": {
-      "matchCount": 28,
+      "matchCount": 30,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
+      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
     },
     "Microsoft.Cache/redisEnterprise:readonly_patterns:^redundancyMode$": {
-      "matchCount": 28,
+      "matchCount": 30,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
+      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^controlPlanePluginProfiles$": {
-      "matchCount": 28,
+      "matchCount": 30,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
+      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
     },
     "Microsoft.ContainerService/managedClusters:custom_patterns:^securityProfile\\.defender$": {
       "matchCount": 6,
@@ -86,14 +86,14 @@
       "lastMatched": "2026-01-28T07:36:35.396763+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^ingressProfile\\.webAppRouting\\.nginx$": {
-      "matchCount": 28,
+      "matchCount": 30,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
+      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
     },
     "Microsoft.ContainerService/managedClusters:readonly_patterns:^kind$": {
-      "matchCount": 28,
+      "matchCount": 30,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
+      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
     },
     "Microsoft.ContainerService/managedClusters:custom_patterns:^storageProfile$": {
       "matchCount": 6,
@@ -101,19 +101,19 @@
       "lastMatched": "2026-01-28T07:36:35.396763+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^nodeProvisioningProfile$": {
-      "matchCount": 28,
+      "matchCount": 30,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
+      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^networkProfile\\.advancedNetworking\\.security\\.transitEncryption$": {
-      "matchCount": 27,
+      "matchCount": 29,
       "firstMatched": "2026-01-28T07:27:16.893220+00:00",
-      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
+      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
     },
     "Microsoft.ContainerService/managedClusters:custom_patterns:^agentPoolProfiles\\[\\d+\\]\\.orchestratorVersion$": {
-      "matchCount": 26,
+      "matchCount": 28,
       "firstMatched": "2026-01-28T07:27:16.893220+00:00",
-      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
+      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
     },
     "Microsoft.ContainerService/managedClusters:custom_patterns:^agentPoolProfiles\\.\\d+\\.count$": {
       "matchCount": 5,
@@ -121,9 +121,9 @@
       "lastMatched": "2026-01-28T07:36:35.396763+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^networkProfile\\.podCidrs$": {
-      "matchCount": 27,
+      "matchCount": 29,
       "firstMatched": "2026-01-28T07:27:16.893220+00:00",
-      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
+      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
     },
     "Microsoft.ContainerService/managedClusters:custom_patterns:^agentPoolProfiles\\.\\d+\\.upgradeSettings$": {
       "matchCount": 4,
@@ -131,9 +131,9 @@
       "lastMatched": "2026-01-28T07:31:24.410687+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^networkProfile\\.serviceCidrs$": {
-      "matchCount": 27,
+      "matchCount": 29,
       "firstMatched": "2026-01-28T07:27:16.893220+00:00",
-      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
+      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
     },
     "Microsoft.ContainerService/managedClusters:custom_patterns:^agentPoolProfiles\\.\\d+\\.securityProfile$": {
       "matchCount": 4,
@@ -141,39 +141,39 @@
       "lastMatched": "2026-01-28T07:31:24.410687+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.osDiskSizeGB$": {
-      "matchCount": 23,
+      "matchCount": 25,
       "firstMatched": "2026-01-28T07:36:35.396763+00:00",
-      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
+      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.upgradeSettings$": {
-      "matchCount": 23,
+      "matchCount": 25,
       "firstMatched": "2026-01-28T07:36:35.396763+00:00",
-      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
+      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.osSKU$": {
-      "matchCount": 23,
+      "matchCount": 25,
       "firstMatched": "2026-01-28T07:36:35.396763+00:00",
-      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
+      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
     },
     "Microsoft.ContainerRegistry/registries:auto_managed_patterns:^roleAssignmentMode$": {
-      "matchCount": 23,
+      "matchCount": 25,
       "firstMatched": "2026-01-28T07:36:35.396763+00:00",
-      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
+      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.securityProfile$": {
-      "matchCount": 23,
+      "matchCount": 25,
       "firstMatched": "2026-01-28T07:36:35.396763+00:00",
-      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
+      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.osDiskType$": {
-      "matchCount": 23,
+      "matchCount": 25,
       "firstMatched": "2026-01-28T07:36:35.396763+00:00",
-      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
+      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^autoScalerProfile\\.skip-nodes-with-local-storage$": {
-      "matchCount": 23,
+      "matchCount": 25,
       "firstMatched": "2026-01-28T07:36:35.396763+00:00",
-      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
+      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
     },
     "Microsoft.Network/virtualNetworks:auto_managed_patterns:^subnets\\..*\\.properties\\.networkSecurityGroup$": {
       "matchCount": 2,
@@ -181,39 +181,39 @@
       "lastMatched": "2026-01-28T07:41:58.154706+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^securityProfile\\.defender$": {
-      "matchCount": 22,
+      "matchCount": 24,
       "firstMatched": "2026-01-28T07:40:32.040732+00:00",
-      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
+      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.count$": {
-      "matchCount": 22,
+      "matchCount": 24,
       "firstMatched": "2026-01-28T07:40:32.040732+00:00",
-      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
+      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^storageProfile$": {
-      "matchCount": 22,
+      "matchCount": 24,
       "firstMatched": "2026-01-28T07:40:32.040732+00:00",
-      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
+      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^addonProfiles$": {
-      "matchCount": 22,
+      "matchCount": 24,
       "firstMatched": "2026-01-28T07:40:32.040732+00:00",
-      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
+      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^securityProfile\\.imageCleaner$": {
-      "matchCount": 22,
+      "matchCount": 24,
       "firstMatched": "2026-01-28T07:40:32.040732+00:00",
-      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
+      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
     },
     "Microsoft.Network/virtualNetworks:auto_managed_patterns:^privateEndpointVNetPolicies$": {
-      "matchCount": 22,
+      "matchCount": 24,
       "firstMatched": "2026-01-28T07:40:32.040732+00:00",
-      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
+      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^windowsProfile$": {
-      "matchCount": 22,
+      "matchCount": 24,
       "firstMatched": "2026-01-28T07:40:32.040732+00:00",
-      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
+      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\[\\d+\\]\\.orchestratorVersion$": {
       "matchCount": 1,
@@ -221,14 +221,14 @@
       "lastMatched": "2026-01-28T07:48:47.022446+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^serviceMeshProfile$": {
-      "matchCount": 13,
+      "matchCount": 15,
       "firstMatched": "2026-02-02T09:46:15.864264+00:00",
-      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
+      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
     },
     "Microsoft.ContainerRegistry/registries:auto_managed_patterns:^networkRuleBypassAllowedForTasks$": {
-      "matchCount": 10,
+      "matchCount": 12,
       "firstMatched": "2026-03-04T00:59:09.421623+00:00",
-      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
+      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
     },
     "Microsoft.Authorization/roleAssignments:auto_managed_patterns:^principalId$": {
       "matchCount": 1,
@@ -241,20 +241,25 @@
       "lastMatched": "2026-03-04T00:59:09.421623+00:00"
     },
     "Microsoft.Network/publicIPAddresses:auto_managed_patterns:^ipTags$": {
-      "matchCount": 10,
+      "matchCount": 12,
       "firstMatched": "2026-03-04T00:59:09.421623+00:00",
-      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
+      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
     },
     "Microsoft.Network/virtualNetworks/subnets/providers/roleAssignments:auto_managed_patterns:^principalId$": {
-      "matchCount": 9,
+      "matchCount": 11,
       "firstMatched": "2026-03-04T01:01:54.287895+00:00",
-      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
+      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
     },
     "Microsoft.Network/virtualNetworks/subnets/providers/roleAssignments:auto_managed_patterns:^principalType$": {
-      "matchCount": 9,
+      "matchCount": 11,
       "firstMatched": "2026-03-04T01:01:54.287895+00:00",
-      "lastMatched": "2026-03-14T08:41:37.654770+00:00"
+      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
+    },
+    "Microsoft.ContainerService/managedClusters:custom_patterns:^kubernetesVersion$": {
+      "matchCount": 1,
+      "firstMatched": "2026-03-16T05:33:18.741455+00:00",
+      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
     }
   },
-  "lastRun": "2026-03-14T08:41:37.654770+00:00"
+  "lastRun": "2026-03-16T05:33:18.741455+00:00"
 }


### PR DESCRIPTION
## 概要

Bicep what-if アナライザーの `noise_patterns.json` に `kubernetesVersion` パターンを追加。

## 変更内容

- `Microsoft.ContainerService/managedClusters` の `custom_patterns` に `^kubernetesVersion$` を追加
- 分類: ⚠️ 要確認（`orchestratorVersion` と同じ扱い）
- マイナーバージョンが一致していればパッチ差異は AKS の自動適用によるもの

## 背景

what-if 実行時に `~ properties.kubernetesVersion` が ❓（未分類）として報告されていた。ARM スキーマを調査し、readOnly ではなくユーザー指定プロパティであることを確認。ただし Bicep でマイナーバージョンのみ指定（例: `1.33`）する場合、デプロイ済みクラスターのフルパッチバージョン（例: `1.33.x`）との差異が検出される。これは既存の `orchestratorVersion` パターンと同じ挙動のため、同一分類で追加。

## 検証

- JSON 構文検証: ✅
- アナライザー再実行: ✅（`kubernetesVersion` が ❓ → ⚠️ に変化）
