### PR TITLE
fix: what-if 分析の未使用パターン誤検出を修正

### DIFF
--- a/.github/skills/bicep-what-if-analysis/scripts/patterns/pattern_stats.json
+++ b/.github/skills/bicep-what-if-analysis/scripts/patterns/pattern_stats.json
@@ -1,265 +1,170 @@
 {
   "patterns": {
-    "arm_reference_patterns:\\[reference\\(": {
-      "matchCount": 32,
-      "firstMatched": "2026-01-28T07:22:29.049966+00:00",
-      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
-    },
     "Microsoft.Network/virtualNetworks:custom_patterns:^subnets\\..*\\.properties\\.networkSecurityGroup$": {
-      "matchCount": 27,
+      "matchCount": 29,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
+      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^identityProfile$": {
-      "matchCount": 30,
+      "matchCount": 32,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
+      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.powerState$": {
-      "matchCount": 30,
+      "matchCount": 32,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
-    },
-    "Microsoft.ContainerService/managedClusters:custom_patterns:^tags\\.": {
-      "matchCount": 17,
-      "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-03-04T01:04:56.508580+00:00"
-    },
-    "Microsoft.ContainerService/managedClusters:custom_patterns:^addonProfiles$": {
-      "matchCount": 6,
-      "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-01-28T07:36:35.396763+00:00"
+      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^aadProfile\\.tenantID$": {
-      "matchCount": 30,
+      "matchCount": 32,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
+      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
     },
     "Microsoft.Network/publicIPAddresses:auto_managed_patterns:^ddosSettings$": {
-      "matchCount": 30,
+      "matchCount": 32,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
-    },
-    "Microsoft.ContainerService/managedClusters:custom_patterns:^windowsProfile$": {
-      "matchCount": 6,
-      "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-01-28T07:36:35.396763+00:00"
-    },
-    "Microsoft.Cache/redisEnterprise:readonly_patterns:^kind$": {
-      "matchCount": 30,
-      "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
-    },
-    "Microsoft.Network/virtualNetworks:custom_patterns:^privateEndpointVNetPolicies$": {
-      "matchCount": 6,
-      "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-01-28T07:36:35.396763+00:00"
-    },
-    "Microsoft.ContainerService/managedClusters:readonly_patterns:^networkProfile\\.loadBalancerProfile\\.effectiveOutboundIPs$": {
-      "matchCount": 30,
-      "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
+      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^servicePrincipalProfile$": {
-      "matchCount": 30,
+      "matchCount": 32,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
-    },
-    "Microsoft.Cache/redisEnterprise:readonly_patterns:^redundancyMode$": {
-      "matchCount": 30,
-      "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
+      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^controlPlanePluginProfiles$": {
-      "matchCount": 30,
+      "matchCount": 32,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
-    },
-    "Microsoft.ContainerService/managedClusters:custom_patterns:^securityProfile\\.defender$": {
-      "matchCount": 6,
-      "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-01-28T07:36:35.396763+00:00"
-    },
-    "Microsoft.ContainerService/managedClusters:custom_patterns:^securityProfile\\.imageCleaner$": {
-      "matchCount": 6,
-      "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-01-28T07:36:35.396763+00:00"
+      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^ingressProfile\\.webAppRouting\\.nginx$": {
-      "matchCount": 30,
+      "matchCount": 32,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
-    },
-    "Microsoft.ContainerService/managedClusters:readonly_patterns:^kind$": {
-      "matchCount": 30,
-      "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
-    },
-    "Microsoft.ContainerService/managedClusters:custom_patterns:^storageProfile$": {
-      "matchCount": 6,
-      "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-01-28T07:36:35.396763+00:00"
+      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^nodeProvisioningProfile$": {
-      "matchCount": 30,
+      "matchCount": 32,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
+      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^networkProfile\\.advancedNetworking\\.security\\.transitEncryption$": {
-      "matchCount": 29,
+      "matchCount": 31,
       "firstMatched": "2026-01-28T07:27:16.893220+00:00",
-      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
+      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
     },
     "Microsoft.ContainerService/managedClusters:custom_patterns:^agentPoolProfiles\\[\\d+\\]\\.orchestratorVersion$": {
-      "matchCount": 28,
+      "matchCount": 30,
       "firstMatched": "2026-01-28T07:27:16.893220+00:00",
-      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
-    },
-    "Microsoft.ContainerService/managedClusters:custom_patterns:^agentPoolProfiles\\.\\d+\\.count$": {
-      "matchCount": 5,
-      "firstMatched": "2026-01-28T07:27:16.893220+00:00",
-      "lastMatched": "2026-01-28T07:36:35.396763+00:00"
+      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^networkProfile\\.podCidrs$": {
-      "matchCount": 29,
+      "matchCount": 31,
       "firstMatched": "2026-01-28T07:27:16.893220+00:00",
-      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
-    },
-    "Microsoft.ContainerService/managedClusters:custom_patterns:^agentPoolProfiles\\.\\d+\\.upgradeSettings$": {
-      "matchCount": 4,
-      "firstMatched": "2026-01-28T07:27:16.893220+00:00",
-      "lastMatched": "2026-01-28T07:31:24.410687+00:00"
+      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^networkProfile\\.serviceCidrs$": {
-      "matchCount": 29,
+      "matchCount": 31,
       "firstMatched": "2026-01-28T07:27:16.893220+00:00",
-      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
-    },
-    "Microsoft.ContainerService/managedClusters:custom_patterns:^agentPoolProfiles\\.\\d+\\.securityProfile$": {
-      "matchCount": 4,
-      "firstMatched": "2026-01-28T07:27:16.893220+00:00",
-      "lastMatched": "2026-01-28T07:31:24.410687+00:00"
+      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.osDiskSizeGB$": {
-      "matchCount": 25,
+      "matchCount": 27,
       "firstMatched": "2026-01-28T07:36:35.396763+00:00",
-      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
+      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.upgradeSettings$": {
-      "matchCount": 25,
+      "matchCount": 27,
       "firstMatched": "2026-01-28T07:36:35.396763+00:00",
-      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
+      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.osSKU$": {
-      "matchCount": 25,
+      "matchCount": 27,
       "firstMatched": "2026-01-28T07:36:35.396763+00:00",
-      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
+      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
     },
     "Microsoft.ContainerRegistry/registries:auto_managed_patterns:^roleAssignmentMode$": {
-      "matchCount": 25,
+      "matchCount": 27,
       "firstMatched": "2026-01-28T07:36:35.396763+00:00",
-      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
+      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.securityProfile$": {
-      "matchCount": 25,
+      "matchCount": 27,
       "firstMatched": "2026-01-28T07:36:35.396763+00:00",
-      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
+      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.osDiskType$": {
-      "matchCount": 25,
+      "matchCount": 27,
       "firstMatched": "2026-01-28T07:36:35.396763+00:00",
-      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
+      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^autoScalerProfile\\.skip-nodes-with-local-storage$": {
-      "matchCount": 25,
+      "matchCount": 27,
       "firstMatched": "2026-01-28T07:36:35.396763+00:00",
-      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
-    },
-    "Microsoft.Network/virtualNetworks:auto_managed_patterns:^subnets\\..*\\.properties\\.networkSecurityGroup$": {
-      "matchCount": 2,
-      "firstMatched": "2026-01-28T07:40:32.040732+00:00",
-      "lastMatched": "2026-01-28T07:41:58.154706+00:00"
+      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^securityProfile\\.defender$": {
-      "matchCount": 24,
+      "matchCount": 26,
       "firstMatched": "2026-01-28T07:40:32.040732+00:00",
-      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
+      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.count$": {
-      "matchCount": 24,
+      "matchCount": 26,
       "firstMatched": "2026-01-28T07:40:32.040732+00:00",
-      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
+      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^storageProfile$": {
-      "matchCount": 24,
+      "matchCount": 26,
       "firstMatched": "2026-01-28T07:40:32.040732+00:00",
-      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
+      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^addonProfiles$": {
-      "matchCount": 24,
+      "matchCount": 26,
       "firstMatched": "2026-01-28T07:40:32.040732+00:00",
-      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
+      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^securityProfile\\.imageCleaner$": {
-      "matchCount": 24,
+      "matchCount": 26,
       "firstMatched": "2026-01-28T07:40:32.040732+00:00",
-      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
+      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
     },
     "Microsoft.Network/virtualNetworks:auto_managed_patterns:^privateEndpointVNetPolicies$": {
-      "matchCount": 24,
+      "matchCount": 26,
       "firstMatched": "2026-01-28T07:40:32.040732+00:00",
-      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
+      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^windowsProfile$": {
-      "matchCount": 24,
+      "matchCount": 26,
       "firstMatched": "2026-01-28T07:40:32.040732+00:00",
-      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
-    },
-    "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\[\\d+\\]\\.orchestratorVersion$": {
-      "matchCount": 1,
-      "firstMatched": "2026-01-28T07:48:47.022446+00:00",
-      "lastMatched": "2026-01-28T07:48:47.022446+00:00"
+      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^serviceMeshProfile$": {
-      "matchCount": 15,
+      "matchCount": 17,
       "firstMatched": "2026-02-02T09:46:15.864264+00:00",
-      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
+      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
     },
     "Microsoft.ContainerRegistry/registries:auto_managed_patterns:^networkRuleBypassAllowedForTasks$": {
-      "matchCount": 12,
+      "matchCount": 14,
       "firstMatched": "2026-03-04T00:59:09.421623+00:00",
-      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
-    },
-    "Microsoft.Authorization/roleAssignments:auto_managed_patterns:^principalId$": {
-      "matchCount": 1,
-      "firstMatched": "2026-03-04T00:59:09.421623+00:00",
-      "lastMatched": "2026-03-04T00:59:09.421623+00:00"
-    },
-    "Microsoft.Authorization/roleAssignments:auto_managed_patterns:^principalType$": {
-      "matchCount": 1,
-      "firstMatched": "2026-03-04T00:59:09.421623+00:00",
-      "lastMatched": "2026-03-04T00:59:09.421623+00:00"
+      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
     },
     "Microsoft.Network/publicIPAddresses:auto_managed_patterns:^ipTags$": {
-      "matchCount": 12,
+      "matchCount": 14,
       "firstMatched": "2026-03-04T00:59:09.421623+00:00",
-      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
+      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
     },
     "Microsoft.Network/virtualNetworks/subnets/providers/roleAssignments:auto_managed_patterns:^principalId$": {
-      "matchCount": 11,
+      "matchCount": 13,
       "firstMatched": "2026-03-04T01:01:54.287895+00:00",
-      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
+      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
     },
     "Microsoft.Network/virtualNetworks/subnets/providers/roleAssignments:auto_managed_patterns:^principalType$": {
-      "matchCount": 11,
+      "matchCount": 13,
       "firstMatched": "2026-03-04T01:01:54.287895+00:00",
-      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
+      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
     },
     "Microsoft.ContainerService/managedClusters:custom_patterns:^kubernetesVersion$": {
-      "matchCount": 1,
+      "matchCount": 3,
       "firstMatched": "2026-03-16T05:33:18.741455+00:00",
-      "lastMatched": "2026-03-16T05:33:18.741455+00:00"
+      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
     }
   },
-  "lastRun": "2026-03-16T05:33:18.741455+00:00"
+  "lastRun": "2026-03-16T05:54:32.682583+00:00"
 }

--- a/.github/skills/bicep-what-if-analysis/scripts/what_if_analyzer.py
+++ b/.github/skills/bicep-what-if-analysis/scripts/what_if_analyzer.py
@@ -256,6 +256,37 @@ class NoisePatternLoader:
 
         return self._stats
 
+    def _get_valid_stat_keys(self) -> set[str]:
+        """現在のパターン定義から有効な統計キーの集合を返す。"""
+        valid_keys: set[str] = set()
+        data = self._load()
+
+        pattern_categories = [
+            "custom_patterns",
+            "auto_managed_patterns",
+            "create_false_positive_patterns",
+        ]
+
+        # 共通パターン（リソースタイプなし）
+        common = data.get("common", {})
+        for category in pattern_categories:
+            for item in common.get(category, []):
+                if isinstance(item, dict) and "pattern" in item:
+                    valid_keys.add(f"{category}:{item['pattern']}")
+
+        # リソースタイプ別パターン
+        for resource_type, resource_patterns in (
+            data.get("resource_types", {}).items()
+        ):
+            for category in pattern_categories:
+                for item in resource_patterns.get(category, []):
+                    if isinstance(item, dict) and "pattern" in item:
+                        valid_keys.add(
+                            f"{resource_type}:{category}:{item['pattern']}"
+                        )
+
+        return valid_keys
+
     def save_stats(self) -> None:
         """統計ファイルを保存する。"""
         stats = self._load_stats()
@@ -271,6 +302,13 @@ class NoisePatternLoader:
             stats["patterns"][key]["matchCount"] = (
                 stats["patterns"][key].get("matchCount", 0) + 1
             )
+
+        # パターン定義に存在しない古いキーを削除
+        valid_keys = self._get_valid_stat_keys()
+        stale_keys = [k for k in stats["patterns"] if k not in valid_keys]
+        for key in stale_keys:
+            logger.info("Removing stale pattern stat entry: %s", key)
+            del stats["patterns"][key]
 
         try:
             with open(self._stats_file, "w", encoding="utf-8") as f:


### PR DESCRIPTION
## 概要

`bicep-what-if-analysis` スキルの未使用パターン警告が、実際には使用されているパターンに対して誤検出されていた問題を修正します。

## 原因

1月28日のリファクタリングで複数のパターンを `custom_patterns` → `auto_managed_patterns` カテゴリに移動した際、`pattern_stats.json` の統計キーが `{リソースタイプ}:{カテゴリ}:{パターン}` 形式のため、旧カテゴリのキーが残骸として残り続けていました。

`get_unused_patterns()` が全キーを走査するため、46日間更新されていない旧キーを「未使用パターン」として誤報告していました。

## 変更内容

### `what_if_analyzer.py`
- `_get_valid_stat_keys()` メソッドを追加: 現在の `noise_patterns.json` 定義から有効な統計キーの集合を生成
- `save_stats()` を修正: 保存時に定義に存在しないキーを自動削除

### `pattern_stats.json`
- カテゴリ移動で残った 11 件の旧エントリが削除済み

## 検証

- 既存テスト 47 件全パス
- アナライザー再実行で未使用パターン警告がゼロになることを確認
