### PR TITLE
chore: Azure API バージョンを最新安定版に更新

### DIFF
--- a/infra/modules/aks.bicep
+++ b/infra/modules/aks.bicep
@@ -287,7 +287,7 @@ resource aksMaintenanceNodeConf 'Microsoft.ContainerService/managedClusters/main
 // Node OS auto-upgrade alert (native resource)
 // TODO: Migrate to GA API version when available
 // Check: az provider show -n Microsoft.Insights --query "resourceTypes[?resourceType=='scheduledQueryRules'].apiVersions" -o tsv
-resource aksNodeOSAutoUpgradeAlertRule 'Microsoft.Insights/scheduledQueryRules@2025-01-01-preview' = {
+resource aksNodeOSAutoUpgradeAlertRule 'Microsoft.Insights/scheduledQueryRules@2023-12-01' = {
   name: 'aks-nodeos-autoupgrade'
   location: location
   tags: tags

--- a/infra/modules/chaos/experiments.bicep
+++ b/infra/modules/chaos/experiments.bicep
@@ -58,48 +58,48 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2025-06-02-previ
   scope: resourceGroup()
 }
 
-resource chaosTarget 'Microsoft.Chaos/targets@2024-01-01' = {
+resource chaosTarget 'Microsoft.Chaos/targets@2025-01-01' = {
   name: 'microsoft-azurekubernetesservicechaosmesh'
   scope: aksCluster
   properties: {}
 }
 
-resource chaosCapabilityPodChaos 'Microsoft.Chaos/targets/capabilities@2024-01-01' = if (enablePodChaos) {
+resource chaosCapabilityPodChaos 'Microsoft.Chaos/targets/capabilities@2025-01-01' = if (enablePodChaos) {
   name: 'podChaos-2.2'
   parent: chaosTarget
 }
 
-resource chaosCapabilityNetworkChaos 'Microsoft.Chaos/targets/capabilities@2024-01-01' = if (enableNetworkChaos) {
+resource chaosCapabilityNetworkChaos 'Microsoft.Chaos/targets/capabilities@2025-01-01' = if (enableNetworkChaos) {
   name: 'networkChaos-2.2'
   parent: chaosTarget
 }
 
-resource chaosCapabilityStressChaos 'Microsoft.Chaos/targets/capabilities@2024-01-01' = if (enableStressChaos) {
+resource chaosCapabilityStressChaos 'Microsoft.Chaos/targets/capabilities@2025-01-01' = if (enableStressChaos) {
   name: 'stressChaos-2.2'
   parent: chaosTarget
 }
 
-resource chaosCapabilityIOChaos 'Microsoft.Chaos/targets/capabilities@2024-01-01' = if (enableIOChaos) {
+resource chaosCapabilityIOChaos 'Microsoft.Chaos/targets/capabilities@2025-01-01' = if (enableIOChaos) {
   name: 'ioChaos-2.2'
   parent: chaosTarget
 }
 
-resource chaosCapabilityTimeChaos 'Microsoft.Chaos/targets/capabilities@2024-01-01' = if (enableTimeChaos) {
+resource chaosCapabilityTimeChaos 'Microsoft.Chaos/targets/capabilities@2025-01-01' = if (enableTimeChaos) {
   name: 'timeChaos-2.2'
   parent: chaosTarget
 }
 
-resource chaosCapabilityKernelChaos 'Microsoft.Chaos/targets/capabilities@2024-01-01' = if (enableKernelChaos) {
+resource chaosCapabilityKernelChaos 'Microsoft.Chaos/targets/capabilities@2025-01-01' = if (enableKernelChaos) {
   name: 'kernelChaos-2.2'
   parent: chaosTarget
 }
 
-resource chaosCapabilityHTTPChaos 'Microsoft.Chaos/targets/capabilities@2024-01-01' = if (enableHTTPChaos) {
+resource chaosCapabilityHTTPChaos 'Microsoft.Chaos/targets/capabilities@2025-01-01' = if (enableHTTPChaos) {
   name: 'httpChaos-2.2'
   parent: chaosTarget
 }
 
-resource chaosCapabilityDNSChaos 'Microsoft.Chaos/targets/capabilities@2024-01-01' = if (enableDNSChaos) {
+resource chaosCapabilityDNSChaos 'Microsoft.Chaos/targets/capabilities@2025-01-01' = if (enableDNSChaos) {
   name: 'dnsChaos-2.2'
   parent: chaosTarget
 }
@@ -238,7 +238,7 @@ var dnsChaosSpec = {
   }
 }
 
-resource expPodChaos 'Microsoft.Chaos/experiments@2024-01-01' = if (enablePodChaos) {
+resource expPodChaos 'Microsoft.Chaos/experiments@2025-01-01' = if (enablePodChaos) {
   name: 'exp-aks-pod-failure'
   location: location
   identity: {
@@ -274,7 +274,7 @@ resource expPodChaos 'Microsoft.Chaos/experiments@2024-01-01' = if (enablePodCha
   }
 }
 
-resource expNetworkChaos 'Microsoft.Chaos/experiments@2024-01-01' = if (enableNetworkChaos) {
+resource expNetworkChaos 'Microsoft.Chaos/experiments@2025-01-01' = if (enableNetworkChaos) {
   name: 'exp-aks-network-delay'
   location: location
   identity: {
@@ -310,7 +310,7 @@ resource expNetworkChaos 'Microsoft.Chaos/experiments@2024-01-01' = if (enableNe
   }
 }
 
-resource expNetworkChaosLoss 'Microsoft.Chaos/experiments@2024-01-01' = if (enableNetworkChaosLoss) {
+resource expNetworkChaosLoss 'Microsoft.Chaos/experiments@2025-01-01' = if (enableNetworkChaosLoss) {
   name: 'exp-aks-network-loss'
   location: location
   identity: {
@@ -346,7 +346,7 @@ resource expNetworkChaosLoss 'Microsoft.Chaos/experiments@2024-01-01' = if (enab
   }
 }
 
-resource expStressChaos 'Microsoft.Chaos/experiments@2024-01-01' = if (enableStressChaos) {
+resource expStressChaos 'Microsoft.Chaos/experiments@2025-01-01' = if (enableStressChaos) {
   name: 'exp-aks-stress'
   location: location
   identity: {
@@ -382,7 +382,7 @@ resource expStressChaos 'Microsoft.Chaos/experiments@2024-01-01' = if (enableStr
   }
 }
 
-resource expIOChaos 'Microsoft.Chaos/experiments@2024-01-01' = if (enableIOChaos) {
+resource expIOChaos 'Microsoft.Chaos/experiments@2025-01-01' = if (enableIOChaos) {
   name: 'exp-aks-io'
   location: location
   identity: {
@@ -418,7 +418,7 @@ resource expIOChaos 'Microsoft.Chaos/experiments@2024-01-01' = if (enableIOChaos
   }
 }
 
-resource expTimeChaos 'Microsoft.Chaos/experiments@2024-01-01' = if (enableTimeChaos) {
+resource expTimeChaos 'Microsoft.Chaos/experiments@2025-01-01' = if (enableTimeChaos) {
   name: 'exp-aks-time'
   location: location
   identity: {
@@ -454,7 +454,7 @@ resource expTimeChaos 'Microsoft.Chaos/experiments@2024-01-01' = if (enableTimeC
   }
 }
 
-resource expKernelChaos 'Microsoft.Chaos/experiments@2024-01-01' = if (enableKernelChaos) {
+resource expKernelChaos 'Microsoft.Chaos/experiments@2025-01-01' = if (enableKernelChaos) {
   name: 'exp-aks-kernel'
   location: location
   identity: {
@@ -489,7 +489,7 @@ resource expKernelChaos 'Microsoft.Chaos/experiments@2024-01-01' = if (enableKer
   }
 }
 
-resource expHTTPChaos 'Microsoft.Chaos/experiments@2024-01-01' = if (enableHTTPChaos) {
+resource expHTTPChaos 'Microsoft.Chaos/experiments@2025-01-01' = if (enableHTTPChaos) {
   name: 'exp-aks-http'
   location: location
   identity: {
@@ -526,7 +526,7 @@ resource expHTTPChaos 'Microsoft.Chaos/experiments@2024-01-01' = if (enableHTTPC
 }
 
 // DNSChaos: inject DNS resolution failures
-resource expDNSChaos 'Microsoft.Chaos/experiments@2024-01-01' = if (enableDNSChaos) {
+resource expDNSChaos 'Microsoft.Chaos/experiments@2025-01-01' = if (enableDNSChaos) {
   name: 'exp-aks-dns'
   location: location
   identity: {

--- a/infra/modules/fleet.bicep
+++ b/infra/modules/fleet.bicep
@@ -98,7 +98,7 @@ resource autoUpgradeProfile 'Microsoft.ContainerService/fleets/autoUpgradeProfil
   }
 }
 
-resource fleetPendingApprovalAlert 'Microsoft.Insights/scheduledQueryRules@2025-01-01-preview' = {
+resource fleetPendingApprovalAlert 'Microsoft.Insights/scheduledQueryRules@2023-12-01' = {
   name: 'fleet-approval-pending'
   location: location
   tags: tags


### PR DESCRIPTION
## 概要

Azure リソースの API バージョンを最新の安定版に更新します。

## 変更内容

### Chaos Studio リソース（`infra/modules/chaos/experiments.bicep`）
- `Microsoft.Chaos/experiments`: `2024-01-01` → `2025-01-01`
- `Microsoft.Chaos/targets`: `2024-01-01` → `2025-01-01`
- `Microsoft.Chaos/targets/capabilities`: `2024-01-01` → `2025-01-01`

### scheduledQueryRules（`infra/modules/aks.bicep`, `infra/modules/fleet.bicep`）
- `Microsoft.Insights/scheduledQueryRules`: `2025-01-01-preview` → `2023-12-01`（GA 化）

### 更新をスキップしたリソース

| リソース | 現在のバージョン | 理由 |
|---|---|---|
| Microsoft.Network/* (4種) | 2024-07-01 | 最新 GA `2025-07-01` で BCP081（Bicep 型定義未対応） |
| Microsoft.ContainerService/fleets/* | 2025-04-01-preview | GA `2025-03-01` で `beforeGates` が BCP037（承認ゲート機能が Bicep 型定義に未対応） |
| Microsoft.ContainerService/managedClusters | 2025-06-02-preview | `advancedNetworking` / `addonAutoscaling` がプレビュー専用機能 |
| managedClusters/maintenanceConfigurations | 2025-06-02-preview | GA 版が存在しない |
| その他 (Authorization, Cache, ACR, Identity, DNS 等) | - | 既に最新 |

## 検証

- `az bicep build` ✅（既存警告のみ、新規警告なし）
- `azd provision` ✅（全リソース正常デプロイ確認済み）

## 備考

Chaos experiment リソースは API バージョン `2025-01-01` に更新しても、ARM デプロイ時にタグ（`azd-env-name`）が適用されない既知の問題が継続しています。
