### PR TITLE
feat: add BlueGreen node pool upgrade strategy (preview)

### DIFF
--- a/.github/skills/bicep-what-if-analysis/scripts/patterns/noise_patterns.json
+++ b/.github/skills/bicep-what-if-analysis/scripts/patterns/noise_patterns.json
@@ -55,6 +55,10 @@
                 {"pattern": "^networkProfile\\.serviceCidrs$", "description": "Service CIDR は自動設定"},
                 {"pattern": "^networkProfile\\.advancedNetworking\\.security\\.transitEncryption$", "description": "トランジット暗号化は自動管理"},
                 {"pattern": "^autoScalerProfile\\.skip-nodes-with-local-storage$", "description": "オートスケーラー設定は Azure が自動設定"},
+                {"pattern": "^agentPoolProfiles\\.\\d+\\.upgradeStrategy$", "description": "BlueGreen アップグレード戦略はプレビュー API 機能のため what-if が差分をノイズ出力"},
+                {"pattern": "^agentPoolProfiles\\.\\d+\\.upgradeSettingsBlueGreen$", "description": "BlueGreen アップグレード設定はプレビュー API 機能のため what-if が差分をノイズ出力"},
+                {"pattern": "^ingressProfile\\.webAppRouting\\.defaultDomain$", "description": "Web App Routing のデフォルトドメインは Azure が自動生成"},
+                {"pattern": "^networkProfile\\.advancedNetworking\\.performance$", "description": "Advanced Networking の performance 設定は advancedNetworking 有効時に Azure が自動追加"},
                 {"pattern": "^addonProfiles$", "description": "アドオンは Bicep の containerInsights 設定に基づき Azure が自動構成"},
                 {"pattern": "^securityProfile\\.defender$", "description": "Defender は Azure のデフォルトで自動有効化"},
                 {"pattern": "^securityProfile\\.imageCleaner$", "description": "イメージクリーナーは Azure のデフォルト設定"},
@@ -138,7 +142,9 @@
             "readonly_patterns": [],
             "auto_managed_patterns": [
                 {"pattern": "^identity\\.principalId$", "description": "SystemAssigned ID のプリンシパル ID は Azure が自動生成"},
-                {"pattern": "^identity\\.tenantId$", "description": "SystemAssigned ID のテナント ID は Azure が自動設定"}
+                {"pattern": "^identity\\.tenantId$", "description": "SystemAssigned ID のテナント ID は Azure が自動設定"},
+                {"pattern": "^tags$", "description": "Chaos experiments のタグは azd/Azure Policy による自動付与でノイズ出力される"},
+                {"pattern": "^steps\\.\\d+\\.branches\\.\\d+\\.actions\\.\\d+\\.parameters\\.\\d+\\.value$", "description": "Chaos Mesh JSON スペックは string() シリアライゼーション差異（キー順序・空白）でノイズ出力"}
             ],
             "custom_patterns": [],
             "known_defaults": []

--- a/.github/skills/bicep-what-if-analysis/scripts/patterns/pattern_stats.json
+++ b/.github/skills/bicep-what-if-analysis/scripts/patterns/pattern_stats.json
@@ -1,149 +1,149 @@
 {
   "patterns": {
     "Microsoft.Network/virtualNetworks:custom_patterns:^subnets\\..*\\.properties\\.networkSecurityGroup$": {
-      "matchCount": 29,
+      "matchCount": 32,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
+      "lastMatched": "2026-03-18T04:33:16.070546+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^identityProfile$": {
-      "matchCount": 32,
+      "matchCount": 35,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
+      "lastMatched": "2026-03-18T04:33:16.070546+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.powerState$": {
-      "matchCount": 32,
+      "matchCount": 35,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
+      "lastMatched": "2026-03-18T04:33:16.070546+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^aadProfile\\.tenantID$": {
-      "matchCount": 32,
+      "matchCount": 35,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
+      "lastMatched": "2026-03-18T04:33:16.070546+00:00"
     },
     "Microsoft.Network/publicIPAddresses:auto_managed_patterns:^ddosSettings$": {
-      "matchCount": 32,
+      "matchCount": 35,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
+      "lastMatched": "2026-03-18T04:33:16.070546+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^servicePrincipalProfile$": {
-      "matchCount": 32,
+      "matchCount": 35,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
+      "lastMatched": "2026-03-18T04:33:16.070546+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^controlPlanePluginProfiles$": {
-      "matchCount": 32,
+      "matchCount": 35,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
+      "lastMatched": "2026-03-18T04:33:16.070546+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^ingressProfile\\.webAppRouting\\.nginx$": {
-      "matchCount": 32,
+      "matchCount": 35,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
+      "lastMatched": "2026-03-18T04:33:16.070546+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^nodeProvisioningProfile$": {
-      "matchCount": 32,
+      "matchCount": 35,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
+      "lastMatched": "2026-03-18T04:33:16.070546+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^networkProfile\\.advancedNetworking\\.security\\.transitEncryption$": {
-      "matchCount": 31,
+      "matchCount": 34,
       "firstMatched": "2026-01-28T07:27:16.893220+00:00",
-      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
+      "lastMatched": "2026-03-18T04:33:16.070546+00:00"
     },
     "Microsoft.ContainerService/managedClusters:custom_patterns:^agentPoolProfiles\\[\\d+\\]\\.orchestratorVersion$": {
-      "matchCount": 30,
+      "matchCount": 33,
       "firstMatched": "2026-01-28T07:27:16.893220+00:00",
-      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
+      "lastMatched": "2026-03-18T04:33:16.070546+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^networkProfile\\.podCidrs$": {
-      "matchCount": 31,
+      "matchCount": 34,
       "firstMatched": "2026-01-28T07:27:16.893220+00:00",
-      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
+      "lastMatched": "2026-03-18T04:33:16.070546+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^networkProfile\\.serviceCidrs$": {
-      "matchCount": 31,
+      "matchCount": 34,
       "firstMatched": "2026-01-28T07:27:16.893220+00:00",
-      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
+      "lastMatched": "2026-03-18T04:33:16.070546+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.osDiskSizeGB$": {
-      "matchCount": 27,
+      "matchCount": 30,
       "firstMatched": "2026-01-28T07:36:35.396763+00:00",
-      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
+      "lastMatched": "2026-03-18T04:33:16.070546+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.upgradeSettings$": {
-      "matchCount": 27,
+      "matchCount": 30,
       "firstMatched": "2026-01-28T07:36:35.396763+00:00",
-      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
+      "lastMatched": "2026-03-18T04:33:16.070546+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.osSKU$": {
-      "matchCount": 27,
+      "matchCount": 30,
       "firstMatched": "2026-01-28T07:36:35.396763+00:00",
-      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
+      "lastMatched": "2026-03-18T04:33:16.070546+00:00"
     },
     "Microsoft.ContainerRegistry/registries:auto_managed_patterns:^roleAssignmentMode$": {
-      "matchCount": 27,
+      "matchCount": 30,
       "firstMatched": "2026-01-28T07:36:35.396763+00:00",
-      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
+      "lastMatched": "2026-03-18T04:33:16.070546+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.securityProfile$": {
-      "matchCount": 27,
+      "matchCount": 30,
       "firstMatched": "2026-01-28T07:36:35.396763+00:00",
-      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
+      "lastMatched": "2026-03-18T04:33:16.070546+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.osDiskType$": {
-      "matchCount": 27,
+      "matchCount": 30,
       "firstMatched": "2026-01-28T07:36:35.396763+00:00",
-      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
+      "lastMatched": "2026-03-18T04:33:16.070546+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^autoScalerProfile\\.skip-nodes-with-local-storage$": {
-      "matchCount": 27,
+      "matchCount": 30,
       "firstMatched": "2026-01-28T07:36:35.396763+00:00",
-      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
+      "lastMatched": "2026-03-18T04:33:16.070546+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^securityProfile\\.defender$": {
-      "matchCount": 26,
+      "matchCount": 29,
       "firstMatched": "2026-01-28T07:40:32.040732+00:00",
-      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
+      "lastMatched": "2026-03-18T04:33:16.070546+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.count$": {
-      "matchCount": 26,
+      "matchCount": 29,
       "firstMatched": "2026-01-28T07:40:32.040732+00:00",
-      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
+      "lastMatched": "2026-03-18T04:33:16.070546+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^storageProfile$": {
-      "matchCount": 26,
+      "matchCount": 29,
       "firstMatched": "2026-01-28T07:40:32.040732+00:00",
-      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
+      "lastMatched": "2026-03-18T04:33:16.070546+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^addonProfiles$": {
-      "matchCount": 26,
+      "matchCount": 29,
       "firstMatched": "2026-01-28T07:40:32.040732+00:00",
-      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
+      "lastMatched": "2026-03-18T04:33:16.070546+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^securityProfile\\.imageCleaner$": {
-      "matchCount": 26,
+      "matchCount": 29,
       "firstMatched": "2026-01-28T07:40:32.040732+00:00",
-      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
+      "lastMatched": "2026-03-18T04:33:16.070546+00:00"
     },
     "Microsoft.Network/virtualNetworks:auto_managed_patterns:^privateEndpointVNetPolicies$": {
-      "matchCount": 26,
+      "matchCount": 29,
       "firstMatched": "2026-01-28T07:40:32.040732+00:00",
-      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
+      "lastMatched": "2026-03-18T04:33:16.070546+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^windowsProfile$": {
-      "matchCount": 26,
+      "matchCount": 29,
       "firstMatched": "2026-01-28T07:40:32.040732+00:00",
-      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
+      "lastMatched": "2026-03-18T04:33:16.070546+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^serviceMeshProfile$": {
-      "matchCount": 17,
+      "matchCount": 20,
       "firstMatched": "2026-02-02T09:46:15.864264+00:00",
-      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
+      "lastMatched": "2026-03-18T04:33:16.070546+00:00"
     },
     "Microsoft.ContainerRegistry/registries:auto_managed_patterns:^networkRuleBypassAllowedForTasks$": {
-      "matchCount": 14,
+      "matchCount": 17,
       "firstMatched": "2026-03-04T00:59:09.421623+00:00",
-      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
+      "lastMatched": "2026-03-18T04:33:16.070546+00:00"
     },
     "Microsoft.Network/publicIPAddresses:auto_managed_patterns:^ipTags$": {
       "matchCount": 14,
@@ -151,20 +151,50 @@
       "lastMatched": "2026-03-16T05:54:32.682583+00:00"
     },
     "Microsoft.Network/virtualNetworks/subnets/providers/roleAssignments:auto_managed_patterns:^principalId$": {
-      "matchCount": 13,
+      "matchCount": 16,
       "firstMatched": "2026-03-04T01:01:54.287895+00:00",
-      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
+      "lastMatched": "2026-03-18T04:33:16.070546+00:00"
     },
     "Microsoft.Network/virtualNetworks/subnets/providers/roleAssignments:auto_managed_patterns:^principalType$": {
-      "matchCount": 13,
+      "matchCount": 16,
       "firstMatched": "2026-03-04T01:01:54.287895+00:00",
-      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
+      "lastMatched": "2026-03-18T04:33:16.070546+00:00"
     },
     "Microsoft.ContainerService/managedClusters:custom_patterns:^kubernetesVersion$": {
       "matchCount": 3,
       "firstMatched": "2026-03-16T05:33:18.741455+00:00",
       "lastMatched": "2026-03-16T05:54:32.682583+00:00"
+    },
+    "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^networkProfile\\.advancedNetworking\\.performance$": {
+      "matchCount": 1,
+      "firstMatched": "2026-03-18T04:33:16.070546+00:00",
+      "lastMatched": "2026-03-18T04:33:16.070546+00:00"
+    },
+    "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.upgradeSettingsBlueGreen$": {
+      "matchCount": 1,
+      "firstMatched": "2026-03-18T04:33:16.070546+00:00",
+      "lastMatched": "2026-03-18T04:33:16.070546+00:00"
+    },
+    "Microsoft.Chaos/experiments:auto_managed_patterns:^tags$": {
+      "matchCount": 1,
+      "firstMatched": "2026-03-18T04:33:16.070546+00:00",
+      "lastMatched": "2026-03-18T04:33:16.070546+00:00"
+    },
+    "Microsoft.Chaos/experiments:auto_managed_patterns:^steps\\.\\d+\\.branches\\.\\d+\\.actions\\.\\d+\\.parameters\\.\\d+\\.value$": {
+      "matchCount": 1,
+      "firstMatched": "2026-03-18T04:33:16.070546+00:00",
+      "lastMatched": "2026-03-18T04:33:16.070546+00:00"
+    },
+    "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.upgradeStrategy$": {
+      "matchCount": 1,
+      "firstMatched": "2026-03-18T04:33:16.070546+00:00",
+      "lastMatched": "2026-03-18T04:33:16.070546+00:00"
+    },
+    "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^ingressProfile\\.webAppRouting\\.defaultDomain$": {
+      "matchCount": 1,
+      "firstMatched": "2026-03-18T04:33:16.070546+00:00",
+      "lastMatched": "2026-03-18T04:33:16.070546+00:00"
     }
   },
-  "lastRun": "2026-03-16T05:54:32.682583+00:00"
+  "lastRun": "2026-03-18T04:33:16.070546+00:00"
 }

--- a/infra/modules/aks.bicep
+++ b/infra/modules/aks.bicep
@@ -144,6 +144,15 @@ var aksBaseSpecificProperties = {
       enableAutoScaling: true
       minCount: 1
       maxCount: 3
+      // Blue-green upgrade strategy for safer node OS auto-upgrades (preview)
+      // Requires API version 2025-08-02-preview or later
+      upgradeStrategy: 'BlueGreen'
+      upgradeSettingsBlueGreen: {
+        drainBatchSize: '50%'
+        drainTimeoutInMinutes: 30
+        batchSoakDurationInMinutes: 15
+        finalSoakDurationInMinutes: 60
+      }
     }
   ]
 }
@@ -195,7 +204,7 @@ resource aksIdentity 'Microsoft.ManagedIdentity/userAssignedIdentities@2024-11-3
 // Reason: addonAutoscaling (VPA) requires preview API
 // Check: az provider show -n Microsoft.ContainerService --query "resourceTypes[?resourceType=='managedClusters'].apiVersions" -o tsv
 #disable-next-line BCP081
-resource aksCluster 'Microsoft.ContainerService/managedClusters@2025-06-02-preview' = {
+resource aksCluster 'Microsoft.ContainerService/managedClusters@2025-08-02-preview' = {
   name: aksName
   location: location
   tags: tags
@@ -265,7 +274,7 @@ output aksIdentityPrincipalId string = aksIdentity.properties.principalId
 // AKS Managed Node OS Upgrade Schedule (weekly on Wednesday)
 // TODO: Migrate to GA API version when available (same as aksCluster)
 #disable-next-line BCP081
-resource aksMaintenanceNodeConf 'Microsoft.ContainerService/managedClusters/maintenanceConfigurations@2025-06-02-preview' = {
+resource aksMaintenanceNodeConf 'Microsoft.ContainerService/managedClusters/maintenanceConfigurations@2025-08-02-preview' = {
   parent: aksCluster
   name: 'aksManagedNodeOSUpgradeSchedule'
   properties: {

--- a/infra/modules/azmonitor/container-insights.bicep
+++ b/infra/modules/azmonitor/container-insights.bicep
@@ -129,7 +129,7 @@ resource dataCollectionRule 'Microsoft.Insights/dataCollectionRules@2024-03-11' 
 }
 
 #disable-next-line BCP081
-resource existingAksCluster 'Microsoft.ContainerService/managedClusters@2025-06-02-preview' existing = {
+resource existingAksCluster 'Microsoft.ContainerService/managedClusters@2025-08-02-preview' existing = {
   name: aksClusterName
 }
 

--- a/infra/modules/chaos/experiments.bicep
+++ b/infra/modules/chaos/experiments.bicep
@@ -53,7 +53,7 @@ param enableDNSChaos bool = true
 param redisHosts array = []
 
 #disable-next-line BCP081
-resource aksCluster 'Microsoft.ContainerService/managedClusters@2025-06-02-preview' existing = {
+resource aksCluster 'Microsoft.ContainerService/managedClusters@2025-08-02-preview' existing = {
   name: last(split(aksId, '/'))
   scope: resourceGroup()
 }

--- a/infra/modules/prometheus/pipeline.bicep
+++ b/infra/modules/prometheus/pipeline.bicep
@@ -69,7 +69,7 @@ resource dataCollectionRule 'Microsoft.Insights/dataCollectionRules@2024-03-11' 
 // Use extension resource with explicit scope to avoid analyzer warnings
 @description('Existing AKS cluster for extension resource scope')
 #disable-next-line BCP081
-resource existingAksCluster 'Microsoft.ContainerService/managedClusters@2025-06-02-preview' existing = {
+resource existingAksCluster 'Microsoft.ContainerService/managedClusters@2025-08-02-preview' existing = {
   name: aksClusterName
 }
 


### PR DESCRIPTION
## Summary

AKS ノードプールに BlueGreen アップグレード戦略（プレビュー）を追加し、ノード OS の自動アップグレードをより安全に実行できるようにします。

## Changes

### Infrastructure (Bicep)
- **BlueGreen アップグレード戦略**: `upgradeStrategy: 'BlueGreen'` と `upgradeSettingsBlueGreen` を AKS エージェントプールに追加
  - `drainBatchSize: 50%` — バッチ単位でのドレイン
  - `drainTimeoutInMinutes: 30` — ドレインタイムアウト
  - `batchSoakDurationInMinutes: 15` — バッチ間のソーク期間
  - `finalSoakDurationInMinutes: 60` — 最終ソーク期間
- **API バージョン更新**: `2025-06-02-preview` → `2025-08-02-preview`（BlueGreen に必要）
  - `infra/modules/aks.bicep`（AKS クラスター本体 + メンテナンス構成）
  - `infra/modules/azmonitor/container-insights.bicep`
  - `infra/modules/chaos/experiments.bicep`
  - `infra/modules/prometheus/pipeline.bicep`

### What-If Noise Patterns
- AKS: `upgradeStrategy`, `upgradeSettingsBlueGreen`（プレビュー API ノイズ）
- AKS: `webAppRouting.defaultDomain`（Azure 自動生成）
- AKS: `advancedNetworking.performance`（Azure 自動追加）
- Chaos: `tags`（azd/Azure Policy 自動付与）
- Chaos: `parameters.value`（JSON シリアライゼーション差異）

## Verification

- [x] `azd provision` で正常にデプロイ完了（約13分）
- [x] `what-if` 分析で全項目が正しく分類されることを確認（❓ 未分類 → 0件）
- [x] プレビュー API (`2025-08-02-preview`) で BlueGreen 設定が正しく適用されていることを確認
- [x] アプリケーション Pod (2/2 Running)、ヘルスチェック (200 OK)、Warning イベントなし
