### PR TITLE
feat: AKS コンテナーネットワークログ（ACNS 保存ログ）の導入

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ graph TD
   - **注記**: ノード関連メトリクスは環境作成直後に収集されないことがあります。これはnode exporterのインストールが他のタスクより優先度が低いためです。最大24時間待つと導入されます。詳細: [Azure/prometheus-collector#483](https://github.com/Azure/prometheus-collector/issues/483)
 - Grafana ダッシュボード: Azure Portal の 対象AKS > Monitoring > Dashboards with Grafana から参照できます。
 - Container Insights: AMA + DCR（`azureMonitorProfile.containerInsights` と DCR/DCRA）によりコンテナログ/メトリクスを収集。
+- コンテナーネットワークログ: ACNS + Cilium の eBPF によるネットワークフローログ。`ContainerNetworkLog` CRD（`k8s/observability/container-network-log.yaml`）で対象 Pod・プロトコル・判定を指定し、DCR 経由で Log Analytics の `ContainerNetworkLogs` テーブルに収集。NetworkChaos / DNSChaos 実験時のフロー可視化に有用。
 
 
 ## 🔥 Chaos実験（Azure Chaos Studio）

--- a/docs/adr/002-container-network-logs.md
+++ b/docs/adr/002-container-network-logs.md
@@ -1,0 +1,22 @@
+# ADR-002: コンテナーネットワークログ（ACNS 保存ログ）の導入
+
+## Status
+
+Accepted
+
+## Context
+
+AKS コンテナーネットワークログが 2026年3月に GA した。本プロジェクトは ACNS + Cilium が有効済みで前提条件を満たしている。Chaos Engineering 実験（NetworkChaos, DNSChaos）でネットワークフローの可視性が不足しており、ADR-001 で記録した「HTTPChaos は Envoy 層で注入されるためアプリ層メトリクスでは観測不可」の課題の延長として、ネットワーク層の可観測性向上が求められた。
+
+## Decision
+
+- **CRD ベースの保存ログ（ContainerNetworkLog）を採用**: ACNS の保存ログモードを使用。CRD で対象 Pod・プロトコル・判定を宣言的に指定し、eBPF でキャプチャしたフローログをノード上に書き出す。Hubble CLI（オンデマンドモード）は mTLS 証明書のセットアップが煩雑で、リアルタイム観測の即時的な必要性も低いため却下。
+- **Log Analytics 連携（DCR ストリーム + DCE）を追加**: ContainerNetworkLogs テーブルへの長期保存と KQL 分析を可能にするため、Container Insights の DCR に `Microsoft-ContainerNetworkLogs` ストリームを追加。高ログ量に対応するため Data Collection Endpoint（DCE）を作成。ノードローカルログのみでは Chaos 実験後の事後分析に不便なため。
+- **L7 フローログは対象外**: ACNS の L7 ポリシーは Istio managed addon との併用不可。本プロジェクトは Gateway API (approuting-istio) を使用しており、L7 ログを有効化できない。現在の `advancedNetworkPolicies: 'FQDN'` は L4 FQDN であり L7 ではない。
+- **CRD のフィルタは chaos-lab namespace の chaos-app Pod に限定**: ログ量とコストを制御するため、全 Pod ではなく実験対象 Pod に絞る。プロトコルは tcp/udp/dns、判定は forwarded/dropped の両方を記録。DNS フローは FQDN ネットワークポリシーの存在により記録される。
+
+## Consequences
+
+- **利点**: NetworkChaos（遅延・ロス）、DNSChaos 実験時のネットワークフローが Log Analytics で検索可能になる。ADR-001 の「Envoy 層で注入される障害はアプリ層で観測不可」の課題に対し、ネットワーク層からの補完情報を提供する。
+- **制約**: CRD の apiVersion (`acn.azure.com/v1alpha1`) はドキュメントがまだプレビュー表記であり、GA 後に変更される可能性がある。L7 フローログは Istio 併用の制約により利用不可。Log Analytics への収集量に応じたコスト増がある（CRD フィルタで軽減）。AKS の `containerNetworkLogs` プロパティは GA Bicep スキーマに未収録のため `#disable-next-line BCP081` で抑制が必要（値は文字列 `'Enabled'`、オブジェクトではない）。
+- **命名の経緯**: Nov 2025 に Retina → Container Network Logs へのリネームが行われた。CRD 名 (`ContainerNetworkLog`)、CLI フラグ (`--enable-container-network-logs`)、DCR ストリーム名 (`Microsoft-ContainerNetworkLogs`)、LA テーブル名 (`ContainerNetworkLogs`) はすべて新名で動作することを検証済み。旧名（`Microsoft-RetinaNetworkFlowLogs` / `RetinaNetworkFlowLogs`）も互換性のため動作するが、新名を採用する。ドキュメントは一部旧名のままだが、Azure CLI のソースコード（`addonconfiguration.py`）は新名を使用している。

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -3,3 +3,4 @@
 | 番号 | タイトル | Status | 作成日 |
 |------|---------|--------|--------|
 | 001 | [マネージド NGINX から Gateway API (App Routing Istio) への移行とアプリ層メトリクスの採用](001-gateway-api-migration-and-app-level-metrics.md) | Accepted | 2026-04-01 |
+| 002 | [コンテナーネットワークログ（ACNS 保存ログ）の導入](002-container-network-logs.md) | Accepted | 2026-04-02 |

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -49,6 +49,9 @@ param enableChaosExperiments bool = true
 @description('Deploy Container Insights Data Collection Rule and Association')
 param enableContainerInsights bool = true
 
+@description('Enable container network logs collection in Container Insights (ACNS + Cilium required)')
+param enableContainerNetworkLogs bool = true
+
 @description('Action Group resource ID for alerts (optional, leave empty for lab use)')
 param actionGroupId string = ''
 
@@ -190,6 +193,7 @@ module aksCluster './modules/aks.bicep' = {
     skuName: aksSkuName
     nodeResourceGroupName: nodeResourceGroupName
     logAnalyticsWorkspaceId: azmonitorCore.outputs.logAnalyticsId
+    enableContainerNetworkLogs: enableContainerNetworkLogs
     actionGroupId: actionGroupId
   }
 }
@@ -242,6 +246,7 @@ module containerInsights './modules/azmonitor/container-insights.bicep' = if (en
     aksClusterResourceId: aksCluster.outputs.aksId
     logAnalyticsWorkspaceId: azmonitorCore.outputs.logAnalyticsId
     nameSuffix: '${appName}-${environment}'
+    enableContainerNetworkLogs: enableContainerNetworkLogs
   }
 }
 

--- a/infra/modules/aks.bicep
+++ b/infra/modules/aks.bicep
@@ -17,6 +17,9 @@ param aksApiSubnetId string = ''
 @description('Log Analytics workspace resource ID for Container Insights')
 param logAnalyticsWorkspaceId string
 
+@description('Enable container network logs collection (ACNS + Cilium required)')
+param enableContainerNetworkLogs bool = true
+
 @description('Action Group resource ID for alerts (optional, leave empty for lab use)')
 param actionGroupId string = ''
 
@@ -52,6 +55,8 @@ var aksCommonProperties = {
     containerInsights: {
       enabled: true
       logAnalyticsWorkspaceResourceId: logAnalyticsWorkspaceId
+      #disable-next-line BCP081
+      containerNetworkLogs: enableContainerNetworkLogs ? 'Enabled' : null
     }
     metrics: {
       enabled: true

--- a/infra/modules/azmonitor/container-insights.bicep
+++ b/infra/modules/azmonitor/container-insights.bicep
@@ -38,6 +38,9 @@ param namespaceFilteringMode string = 'Off'
 @description('Namespaces to include/exclude in data collection')
 param namespacesForDataCollection array = []
 
+@description('Enable container network logs collection (ACNS + Cilium required)')
+param enableContainerNetworkLogs bool = false
+
 @description('Data streams to collect')
 param streams array = [
   'Microsoft-ContainerLog'
@@ -56,6 +59,13 @@ var aksClusterName = split(aksClusterResourceId, '/')[8]
 var dataCollectionRuleNameBase = 'dcr-ci-${nameSuffix}'
 var dataCollectionRuleName = substring(dataCollectionRuleNameBase, 0, min(64, length(dataCollectionRuleNameBase)))
 var dataCollectionRuleAssociationName = 'ContainerInsightsExtension'
+
+// Data Collection Endpoint for high-log-scale-mode (required for container network logs)
+var dataCollectionEndpointNameBase = 'dce-ci-${nameSuffix}'
+var dataCollectionEndpointName = substring(dataCollectionEndpointNameBase, 0, min(44, length(dataCollectionEndpointNameBase)))
+
+// Extract workspace location from workspace resource ID for DCE placement
+var workspaceLocation = location
 
 // Define stream collections based on preset
 var logsAndEventsStreams = [
@@ -81,10 +91,26 @@ var selectedStreams = dataCollectionPreset == 'LogsAndEvents'
   ? logsAndEventsStreams
   : dataCollectionPreset == 'All' ? allStreams : streams
 
+// Add container network logs stream when enabled
+// Stream "Microsoft-ContainerNetworkLogs" maps to the ContainerNetworkLogs LA table.
+var streamsWithNetworkLogs = enableContainerNetworkLogs
+  ? union(selectedStreams, ['Microsoft-ContainerNetworkLogs'])
+  : selectedStreams
+
 // Combine streams with KubeMonAgentEvents
-var streamWithKubeMonAgentEvents = union(selectedStreams, [
+var streamWithKubeMonAgentEvents = union(streamsWithNetworkLogs, [
   'Microsoft-KubeMonAgentEvents'
 ])
+
+// Data Collection Endpoint for high-log-scale-mode ingestion
+// Required when container network logs are enabled due to high log volume
+resource dataCollectionEndpoint 'Microsoft.Insights/dataCollectionEndpoints@2024-03-11' = if (enableContainerNetworkLogs) {
+  name: dataCollectionEndpointName
+  location: workspaceLocation
+  tags: tags
+  kind: 'Linux'
+  properties: {}
+}
 
 resource dataCollectionRule 'Microsoft.Insights/dataCollectionRules@2024-03-11' = {
   name: dataCollectionRuleName
@@ -92,11 +118,12 @@ resource dataCollectionRule 'Microsoft.Insights/dataCollectionRules@2024-03-11' 
   tags: tags
   kind: 'Linux'
   properties: {
+    dataCollectionEndpointId: enableContainerNetworkLogs ? dataCollectionEndpoint.id : null
     dataSources: {
       extensions: [
         {
           name: 'ContainerInsightsExtension'
-          streams: selectedStreams
+          streams: streamsWithNetworkLogs
           extensionSettings: {
             dataCollectionSettings: {
               interval: dataCollectionInterval

--- a/k8s/observability/container-network-log.yaml
+++ b/k8s/observability/container-network-log.yaml
@@ -1,0 +1,36 @@
+apiVersion: acn.azure.com/v1alpha1
+kind: ContainerNetworkLog
+metadata:
+  name: chaos-lab-network-log
+  labels:
+    app.kubernetes.io/part-of: aks-chaos-lab
+    app.kubernetes.io/component: observability
+    app.kubernetes.io/managed-by: kustomize
+spec:
+  includefilters:
+    # Egress: chaos-app から外部への全フロー
+    - name: chaos-app-egress
+      from:
+        labelSelector:
+          matchLabels:
+            app: chaos-app
+      protocol:
+        - tcp
+        - udp
+        - dns
+      verdict:
+        - forwarded
+        - dropped
+    # Ingress: 外部から chaos-app への全フロー
+    - name: chaos-app-ingress
+      to:
+        labelSelector:
+          matchLabels:
+            app: chaos-app
+      protocol:
+        - tcp
+        - udp
+        - dns
+      verdict:
+        - forwarded
+        - dropped

--- a/k8s/observability/kustomization.yaml
+++ b/k8s/observability/kustomization.yaml
@@ -1,7 +1,11 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
-namespace: kube-system
+
+# NOTE: namespace is intentionally omitted.
+# ConfigMaps declare namespace: kube-system in their own metadata.
+# ContainerNetworkLog is cluster-scoped and must not have a namespace set.
 
 resources:
   - ama-metrics-settings-configmap.yaml
   - ama-metrics-prometheus-config.yaml
+  - container-network-log.yaml


### PR DESCRIPTION
## 概要

AKS コンテナーネットワークログ（ACNS 保存ログ）を導入し、Chaos Engineering 実験時のネットワークフロー可視性を向上させる。

## 変更内容

### Kubernetes マニフェスト
- `k8s/observability/container-network-log.yaml`: ContainerNetworkLog CRD を追加。chaos-app Pod の egress/ingress フローを tcp/udp/dns × forwarded/dropped でフィルタリング
- `k8s/observability/kustomization.yaml`: CRD をリソースに追加

### インフラ (Bicep)
- `infra/modules/azmonitor/container-insights.bicep`: DCR に `Microsoft-ContainerNetworkLogs` ストリームを追加、Data Collection Endpoint (DCE) を作成
- `infra/modules/aks.bicep`: `containerNetworkLogs: 'Enabled'` を azureMonitorProfile に追加（`#disable-next-line BCP081` — GA Bicep スキーマ未収録）
- `infra/main.bicep`: `enableContainerNetworkLogs` パラメータを追加し両モジュールに受け渡し

### ドキュメント
- `docs/adr/002-container-network-logs.md`: 設計判断を ADR として記録
- `docs/adr/INDEX.md`: ADR-002 のエントリを追加
- `README.md`: 可観測性セクションにコンテナーネットワークログを追記

## 技術的な注意点

- **DCR ストリーム名**: `Microsoft-ContainerNetworkLogs`（新名）を使用。旧名 `Microsoft-RetinaNetworkFlowLogs` も互換性のため動作するが、Azure CLI ソースコード（`addonconfiguration.py`）が新名を使用しているため新名を採用
- **LA テーブル名**: `ContainerNetworkLogs`（新名）にデータが格納される
- **`containerNetworkLogs` プロパティ**: 値は文字列 `'Enabled'`（オブジェクトではない）。設定により AMA Pod に `AZMON_RETINA_FLOW_LOGS_ENABLED=true` が自動設定される
- **L7 フローログ**: Istio managed addon (approuting-istio) との併用不可のため対象外

## 検証結果

eval 環境 (`aks-aks-chaos-lab-eval`) で検証済み:
- ✅ ContainerNetworkLog CRD 適用 → events.log 生成
- ✅ Fluent Bit inotify 監視 → ログ収集
- ✅ ContainerNetworkLogs テーブルへのデータ取り込み（9700+ レコード確認）
- ✅ CRD ラベルセレクタ修正後も継続的にデータ収集を確認

## 関連

- ADR-001: Gateway API マイグレーションとアプリレベルメトリクス（HTTPChaos の Envoy 層注入問題の背景）
