### PR TITLE
chore: GitHub Actions のアクション最新化とCIトリガー見直し

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,8 @@ name: CI
 
 on:
   push:
-    branches: ["**"]
+    branches: [main]
   pull_request:
-    branches: ["**"]
 
 permissions:
   contents: read
@@ -15,9 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.0.0
         with:
           version-file: "src/pyproject.toml"
           python-version: "3.13"
@@ -32,9 +31,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.0.0
         with:
           version-file: "src/pyproject.toml"
           python-version: "3.13"
@@ -50,9 +49,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.0.0
         with:
           version-file: "src/pyproject.toml"
           python-version: "3.13"
@@ -67,9 +66,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.0.0
         with:
           version-file: "src/pyproject.toml"
           python-version: "3.13"
@@ -84,11 +83,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install Bicep CLI
         run: |
           set -euxo pipefail
-          BICEP_VERSION=v0.40.2
+          BICEP_VERSION=v0.41.2
           mkdir -p "$HOME/.local/bin"
           curl -L -o "$HOME/.local/bin/bicep" "https://github.com/Azure/bicep/releases/download/${BICEP_VERSION}/bicep-linux-x64"
           chmod +x "$HOME/.local/bin/bicep"
@@ -104,7 +103,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install kubeconform
         run: |
           set -euxo pipefail

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -51,12 +51,12 @@ jobs:
       env_name: ${{ env.AZURE_ENV_NAME }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.branch || github.ref_name }}
 
       - name: Azure Login
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -91,12 +91,12 @@ jobs:
       ingress_fqdn: ${{ steps.provision.outputs.ingress_fqdn }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.branch || github.ref_name }}
 
       - name: Azure Login
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -173,17 +173,17 @@ jobs:
     if: (inputs.test_scope || 'full') == 'full'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.branch || github.ref_name }}
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v8.0.0
 
       - name: Smoke test - Health endpoint
         env:
@@ -253,7 +253,7 @@ jobs:
     environment: integration-test
     steps:
       - name: Azure Login
-        uses: azure/login@v2
+        uses: azure/login@v3
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}


### PR DESCRIPTION
## 概要

GitHub Actions ワークフローの定期メンテナンス。アクションの最新化と CI トリガーの見直しを行う。

## 変更内容

### アクションの最新化（Node 24 移行対応）

GitHub Actions ランナーで Node 20 が 2026 年に廃止予定のため、Node 24 対応の最新メジャーバージョンに更新。

| アクション | 変更前 | 変更後 | 備考 |
|------------|--------|--------|------|
| `actions/checkout` | v4 | v6 | Node 24 移行 |
| `astral-sh/setup-uv` | v7 | v8.0.0 | イミュータブルタグ方式に変更 |
| `azure/login` | v2 | v3 | Node 24 移行 |
| `actions/setup-python` | v5 | v6 | Node 24 移行 |
| Bicep CLI | v0.40.2 | v0.41.2 | 最新パッチ |

### CI トリガーの見直し

**変更前:**
```yaml
on:
  push:
    branches: ["**"]
  pull_request:
    branches: ["**"]
```

**変更後:**
```yaml
on:
  push:
    branches: [main]
  pull_request:
```

**理由:** PR が開いている状態でフィーチャーブランチに push すると `push` と `pull_request` の両方が発火し CI が二重実行されていた。`push` を main のみに限定することで解消。main への push は PR マージ後の安全網として残す。

### 変更対象外

- `copilot-setup-steps.yml` — gh-aw 管理（`gh aw update` で更新）
- `aks-updates-analyzer.md` — agentic workflow（従来アクション不使用）
- `Azure/setup-azd@v2`, `Azure/use-kubelogin@v1`, `kubeconform v0.7.0` — 既に最新
