### PR TITLE
feat(acns): enable L7 advanced network policies and add chaos-app ingress L7 CNP

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ graph TD
 - Grafana ダッシュボード: Azure Portal の 対象AKS > Monitoring > Dashboards with Grafana から参照できます。
 - Container Insights: AMA + DCR（`azureMonitorProfile.containerInsights` と DCR/DCRA）によりコンテナログ/メトリクスを収集。
 - コンテナーネットワークログ: ACNS + Cilium の eBPF によるネットワークフローログ。`ContainerNetworkLog` CRD（`k8s/observability/container-network-log.yaml`）で対象 Pod・プロトコル・判定を指定し、DCR 経由で Log Analytics の `ContainerNetworkLogs` テーブルに収集。NetworkChaos / DNSChaos 実験時のフロー可視化に有用。
+- Cilium L7 HTTP メトリクス: ACNS の Advanced Network Policies を `L7` 化（`infra/modules/aks.bicep`）し、chaos-app 宛 ingress に `CiliumNetworkPolicy`（`k8s/base/ciliumnetworkpolicy-ingress-l7.yaml`）で HTTP rule を付与。Hubble が Envoy 経由で `hubble_http_requests_total` / `hubble_http_request_duration_seconds_*` を生成し、Azure Monitor の「Dashboards with Grafana」の **Kubernetes / Networking / L7 Flows (Namespace / Workload)** に描画される。詳細は [ADR-007](docs/adr/007-acns-l7-observability.md) を参照。
 
 
 ## 🔥 Chaos実験（Azure Chaos Studio）

--- a/docs/adr/007-acns-l7-observability.md
+++ b/docs/adr/007-acns-l7-observability.md
@@ -1,0 +1,46 @@
+# ADR-007: ACNS Advanced Network Policies の L7 化と Cilium L7 HTTP 可観測性の導入
+
+## Status
+
+Accepted
+
+## Context
+
+ADR-001 で「HTTPChaos は Envoy 層で注入されるためアプリ層メトリクスでは観測不可」としてクライアント側（Locust）メトリクスでの代替観測に切替えた。ADR-006 で OTLP 経由の App Insights 連携に移行した際、chaos-app の egress から App Insights FQDN が消え、`hubble_dns_queries_total` / `hubble_drop_total` 系のデータ点が激減。データで裏取りした結果、これらは chaos-app の外部通信がなくなった副作用で、CNP 変更自体の誤設定ではないことを確認した。
+
+同時に、Azure Monitor の AKS リソース「Dashboards with Grafana」には以下の L7 系ダッシュボードが提供されていることを確認した。
+- Kubernetes / Networking / L7 Flows (Namespace)
+- Kubernetes / Networking / L7 Flows (Workload)
+
+これらは `hubble_http_requests_total` / `hubble_http_request_duration_seconds_*` を参照するが、本プロジェクトでは当時 `advancedNetworkPolicies: 'FQDN'` 固定であり ACNS の Container Network Security が L7 モードで動いていなかったため、系列が 0 で空のダッシュボードになっていた。ラボの主旨（「試して、データも見て」）と HTTPChaos 観測性の弱さを踏まえ、L7 可観測性を補強する価値が大きいと判断した。
+
+なお ADR-002 の「L7 フローログは対象外」は、Log Analytics の `ContainerNetworkLogs` テーブルへの L7 **フローログ**保存に関する判断であり、本 ADR で扱う Cilium Envoy 経由の L7 **メトリクス**とは別機能である。両者は共存可能。
+
+## Decision
+
+- **ACNS の `advancedNetworkPolicies` を `'FQDN'` → `'L7'` に変更**（`infra/modules/aks.bicep`、Base / Automatic 両モード）。L7 化すると FQDN フィルタも同時に有効化される（ポータル / CLI 仕様）。これにより ACNS に同梱される `ValidatingAdmissionPolicy advanced-networking-validating-policy` の判定が変わり、`CiliumNetworkPolicy` で HTTP L7 rule を使えるようになる。
+- **chaos-app への ingress L7 CNP を追加**（`k8s/base/ciliumnetworkpolicy-ingress-l7.yaml`）。以下の peer / path に限定して HTTP ルールを適用し、Hubble L7 メトリクスを生成する。
+  - `gateway.networking.k8s.io/gateway-name: chaos-app`（App Routing Istio の Envoy pod） → `GET /`, `GET /health`
+  - kube-system namespace（ama-metrics 等） → `GET /metrics`, `GET /health`
+  - host / remote-node entity（kubelet probe） → `GET /health`
+- **egress 側の L7 HTTP 化は見送り**。chaos-app の外部依存は Redis（TCP/6380、TLS）であり HTTP ではない。また OTLP は AMA node エージェント経由でノード IP を直接叩くため、L7 HTTP の可視化対象として意味がない。
+- **ama-metrics の keep-list は既存の `networkobservabilityHubble = "hubble.*"` のまま変更しない**。`hubble_http_*` が自動で収集対象になるため追加設定不要。
+- **ContainerNetworkLogs 側の L7 フローログ有効化は ADR-002 の方針のまま対象外**。Istio 併用時の挙動を含めた検証が別途必要で、今回のスコープ外。
+
+## Consequences
+
+- **利点**:
+  - `hubble_http_requests_total{method, protocol, status, reporter}` と `hubble_http_request_duration_seconds_*` が Prometheus（AMW）に入り、AKS の「Dashboards with Grafana」の L7 Flows (Namespace / Workload) が埋まる。5xx 率、メソッド分布、レイテンシ p50/p95 が即座に可視化される。
+  - HTTPChaos 実験中のリクエスト成功率低下をクラスタ側のメトリクスでも捉えられる（ADR-001 では Locust 側のみに依存していた領域を補完）。Envoy 層の注入なので完全補完ではないが、chaos-app pod が受信した実トラフィックの HTTP 結果は観測できる。
+  - Cilium の L7 visibility は Envoy proxy 経由で実現されるため、CNP の HTTP rule に一致しないリクエストは 403 相当で拒否される。これは副次的に意図しないパスへのアクセスを防ぐセキュリティ効果も持つ。
+
+- **制約 / トレードオフ**:
+  - L7 rule に該当するトラフィックは Cilium Envoy を通るため、レイテンシと CPU/メモリに追加コストが発生する。Lab 規模では無視できる範囲だが、パス追加のたびに CNP の HTTP rule を維持する運用負荷がある。
+  - path を増やすと CNP を更新する必要がある。現在のアプリは `GET /` と `GET /health` のみで、ama-metrics 向けに `GET /metrics` を明示している。
+  - VAP `advanced-networking-validating-policy` が `FQDN` モードでは HTTP L7 rule を deny するため、本 ADR の順序として「先に Bicep で L7 化 → その後 CNP apply」という順序が必須（azd provision 完了後に kubectl apply）。
+
+- **検証済みの事実**:
+  - `azd provision` 後、`kubectl apply -f k8s/base/ciliumnetworkpolicy-ingress-l7.yaml` が VAP を通過して作成されること。
+  - 既存 pod（chaos-app × 2）が Ready を維持し、readiness / startup probe に影響がないこと。
+  - LB 経由で `/` と `/health` に 100 リクエスト送信後、`hubble_http_requests_total{destination="chaos-lab/chaos-app-*", method="get", protocol="http/1.1", status="200", reporter="server"}` が 2 系列（pod ごと）に分かれて計上されること。
+  - `hubble_http_request_duration_seconds_count` も同時に生成されレイテンシ系メトリクスが利用可能になること。

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -8,3 +8,4 @@
 | 004 | [Envoy Gateway メトリクスによる SLO 監視](004-envoy-gateway-metrics-for-slo.md) | Accepted | 2026-04-04 |
 | 005 | [AKS 診断ログの Basic テーブル収集](005-aks-diagnostics-basic-logs.md) | Accepted | 2026-04-07 |
 | 006 | [Application Insights OTLP 統合とベンダー非依存 OTel 計装への移行](006-otlp-vendor-neutral-otel.md) | Accepted | 2026-07-22 |
+| 007 | [ACNS Advanced Network Policies の L7 化と Cilium L7 HTTP 可観測性の導入](007-acns-l7-observability.md) | Accepted | 2026-04-17 |

--- a/infra/modules/aks.bicep
+++ b/infra/modules/aks.bicep
@@ -144,7 +144,7 @@ var aksBaseSpecificProperties = {
       }
       security: {
         enabled: true
-        advancedNetworkPolicies: 'FQDN'
+        advancedNetworkPolicies: 'L7'
       }
     }
   }
@@ -192,7 +192,7 @@ var aksAutomaticSpecificProperties = {
       }
       security: {
         enabled: true
-        advancedNetworkPolicies: 'FQDN'
+        advancedNetworkPolicies: 'L7'
       }
     }
   }

--- a/k8s/base/ciliumnetworkpolicy-ingress-l7.yaml
+++ b/k8s/base/ciliumnetworkpolicy-ingress-l7.yaml
@@ -1,0 +1,61 @@
+apiVersion: cilium.io/v2
+kind: CiliumNetworkPolicy
+metadata:
+  name: chaos-app-ingress-l7
+  namespace: chaos-lab
+  labels:
+    app.kubernetes.io/name: chaos-app
+    app.kubernetes.io/instance: chaos-app
+    app.kubernetes.io/part-of: aks-chaos-lab
+    app.kubernetes.io/component: networkpolicy
+    app.kubernetes.io/managed-by: kustomize
+    app.kubernetes.io/version: "0.1.0"
+spec:
+  endpointSelector:
+    matchLabels:
+      app: chaos-app
+  ingress:
+    # L7 HTTP visibility for traffic from Gateway API (App Routing Istio) Envoy proxy.
+    # Cilium proxies matching traffic through its Envoy, producing
+    # hubble_http_requests_total / hubble_http_request_duration_seconds series
+    # that populate the "Kubernetes / Networking / L7 Flows" Grafana dashboards.
+    - fromEndpoints:
+        - matchLabels:
+            gateway.networking.k8s.io/gateway-name: chaos-app
+      toPorts:
+        - ports:
+            - port: "8000"
+              protocol: TCP
+          rules:
+            http:
+              - method: "GET"
+                path: "/"
+              - method: "GET"
+                path: "/health"
+    # L7 visibility for Prometheus scrape from kube-system (ama-metrics).
+    - fromEndpoints:
+        - matchLabels:
+            k8s:io.kubernetes.pod.namespace: kube-system
+      toPorts:
+        - ports:
+            - port: "8000"
+              protocol: TCP
+          rules:
+            http:
+              - method: "GET"
+                path: "/metrics"
+              - method: "GET"
+                path: "/health"
+    # Kubelet HTTP probes come from the node (host entity). Keep them explicit
+    # so L7 enforcement does not accidentally interfere with readiness/startup probes.
+    - fromEntities:
+        - host
+        - remote-node
+      toPorts:
+        - ports:
+            - port: "8000"
+              protocol: TCP
+          rules:
+            http:
+              - method: "GET"
+                path: "/health"

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -12,6 +12,7 @@ resources:
 - pdb.yaml
 - networkpolicy.yaml
 - ciliumnetworkpolicy-egress-allowlist.yaml
+- ciliumnetworkpolicy-ingress-l7.yaml
 - addon-vpa.yaml
 - instrumentation.yaml
 


### PR DESCRIPTION
## 概要

ACNS の `advancedNetworkPolicies` を `L7` に切り替え、chaos-app 宛 ingress に HTTP L7 rule を持つ `CiliumNetworkPolicy` を追加することで、Azure Monitor の「Dashboards with Grafana」で提供される **Kubernetes / Networking / L7 Flows (Namespace / Workload)** ダッシュボードに実データが流れるようにします。

## 背景

- ADR-006 で OTLP 経由に移行した際、chaos-app の外部通信が消えた副作用で `hubble_dns_*` / `hubble_drop_*` 系列が激減。CNP 変更の誤設定ではなく外部通信消失の帰結であることをデータで確認済み。
- AKS リソースの「Dashboards with Grafana」には L7 Flows 系ダッシュボードが標準提供されているが、`hubble_http_*` を生成するには Cilium Envoy 経由の L7 policy が必要で、本プロジェクトは `advancedNetworkPolicies: 'FQDN'` のため空だった。
- ラボの主旨（「試して、データも見て」）と、ADR-001 で記録済みの「HTTPChaos はアプリ層では観測不可」の補強として、L7 メトリクス追加の価値が高い。

## 変更内容

- `infra/modules/aks.bicep`: `advancedNetworkPolicies: 'FQDN'` → `'L7'`（Base / Automatic 両モード）。
- `k8s/base/ciliumnetworkpolicy-ingress-l7.yaml`: chaos-app 宛 ingress に L7 HTTP rule を追加。
  - `gateway.networking.k8s.io/gateway-name: chaos-app` → `GET /`, `GET /health`
  - `kube-system` namespace → `GET /metrics`, `GET /health`
  - `host` / `remote-node` entity → `GET /health`（kubelet probe 用）
- `k8s/base/kustomization.yaml`: 上記 CNP を resources に追加。
- `docs/adr/007-acns-l7-observability.md`: 新規 ADR。ADR-002 の「L7 フローログ対象外」は LA 保存の話で、今回の Hubble L7 メトリクスとは別機能である点を明記。
- `docs/adr/INDEX.md`, `README.md`: L7 メトリクスの導線を追加。

## 検証

- `az bicep build --file infra/main.bicep`: エラー 0（警告は既存のもの）
- `cd src && make qa`: ruff / ty / pytest 35 passed, 7 skipped
- `azd provision`: 成功（AKS 更新 約 2 分）
- `kubectl apply -f k8s/base/ciliumnetworkpolicy-ingress-l7.yaml`: ACNS の `ValidatingAdmissionPolicy` を通過して作成成功
- chaos-app の両 pod は Ready を維持、readiness / startup probe に影響なし
- Gateway 経由で `/`、`/health` に 100 リクエスト送信後、Prometheus (AMW) 直接クエリで以下を確認
  - `hubble_http_requests_total{destination="chaos-lab/chaos-app-*", method="get", protocol="http/1.1", status="200", reporter="server"}` が pod 単位で 2 系列
  - `hubble_http_request_duration_seconds_count` も同時生成
- ユーザーによる Grafana 画面での Incoming HTTP Requests 表示確認済み

## 前提 / 順序

ACNS の `ValidatingAdmissionPolicy advanced-networking-validating-policy` は `FQDN` モードでは HTTP L7 rule を deny するため、**先に Bicep を L7 化（`azd provision` 完了） → その後 CNP apply（`kubectl apply -k k8s/base`）** という順序が必須。本 PR のマージ後は自動デプロイパイプラインから通常通り反映可能。

## 関連

- Closes: なし（新規強化）
- 関連 ADR: ADR-001（HTTPChaos のアプリ層観測不可）、ADR-002（L7 フローログ対象外の判断）、ADR-006（OTLP 移行で外部通信消失）
- 参考: [Set up Layer 7 policies with ACNS](https://learn.microsoft.com/azure/aks/how-to-apply-l7-policies)
