### PR TITLE
Fix what-if text output filtering

### DIFF
--- a/.github/skills/bicep-what-if-analysis/scripts/patterns/display_config.json
+++ b/.github/skills/bicep-what-if-analysis/scripts/patterns/display_config.json
@@ -27,7 +27,7 @@
         "Microsoft.Chaos/experiments": "Chaos experiment",
         "Microsoft.Authorization/roleAssignments": "Role assignment"
     },
-    "_filtered_resource_types_doc": "azd style テキスト出力で非表示にするリソースタイプ。変更が少ない補助リソースやプラットフォーム自動管理リソースが対象。主要ワークロードリソース（AKS, Chaos experiments 等）はフィルタしないこと。",
+    "_filtered_resource_types_doc": "azd style テキスト出力で NoChange / Ignore / Unsupported などのノイズ表示を抑制するリソースタイプ。Create / Modify / Delete は重要差分を隠さないため、このリストに含まれていても表示する。主要ワークロードリソース（AKS, Chaos experiments 等）はフィルタしないこと。",
     "filtered_resource_types": [
         "microsoft.authorization/roleassignments",
         "microsoft.network/networkinterfaces",

--- a/.github/skills/bicep-what-if-analysis/scripts/patterns/pattern_stats.json
+++ b/.github/skills/bicep-what-if-analysis/scripts/patterns/pattern_stats.json
@@ -1,39 +1,39 @@
 {
   "patterns": {
     "Microsoft.Network/virtualNetworks:custom_patterns:^subnets\\..*\\.properties\\.networkSecurityGroup$": {
-      "matchCount": 33,
+      "matchCount": 34,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-05-06T06:42:04.265653+00:00"
+      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^identityProfile$": {
-      "matchCount": 36,
+      "matchCount": 37,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-05-06T06:42:04.265653+00:00"
+      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.powerState$": {
-      "matchCount": 36,
+      "matchCount": 37,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-05-06T06:42:04.265653+00:00"
+      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^aadProfile\\.tenantID$": {
-      "matchCount": 36,
+      "matchCount": 37,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-05-06T06:42:04.265653+00:00"
+      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
     },
     "Microsoft.Network/publicIPAddresses:auto_managed_patterns:^ddosSettings$": {
-      "matchCount": 36,
+      "matchCount": 37,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-05-06T06:42:04.265653+00:00"
+      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^servicePrincipalProfile$": {
-      "matchCount": 36,
+      "matchCount": 37,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-05-06T06:42:04.265653+00:00"
+      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^controlPlanePluginProfiles$": {
-      "matchCount": 36,
+      "matchCount": 37,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-05-06T06:42:04.265653+00:00"
+      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^ingressProfile\\.webAppRouting\\.nginx$": {
       "matchCount": 35,
@@ -41,39 +41,39 @@
       "lastMatched": "2026-03-18T04:33:16.070546+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^nodeProvisioningProfile$": {
-      "matchCount": 36,
+      "matchCount": 37,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-05-06T06:42:04.265653+00:00"
+      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^networkProfile\\.advancedNetworking\\.security\\.transitEncryption$": {
-      "matchCount": 35,
+      "matchCount": 36,
       "firstMatched": "2026-01-28T07:27:16.893220+00:00",
-      "lastMatched": "2026-05-06T06:42:04.265653+00:00"
+      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
     },
     "Microsoft.ContainerService/managedClusters:custom_patterns:^agentPoolProfiles\\[\\d+\\]\\.orchestratorVersion$": {
-      "matchCount": 34,
+      "matchCount": 35,
       "firstMatched": "2026-01-28T07:27:16.893220+00:00",
-      "lastMatched": "2026-05-06T06:42:04.265653+00:00"
+      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^networkProfile\\.podCidrs$": {
-      "matchCount": 35,
+      "matchCount": 36,
       "firstMatched": "2026-01-28T07:27:16.893220+00:00",
-      "lastMatched": "2026-05-06T06:42:04.265653+00:00"
+      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^networkProfile\\.serviceCidrs$": {
-      "matchCount": 35,
+      "matchCount": 36,
       "firstMatched": "2026-01-28T07:27:16.893220+00:00",
-      "lastMatched": "2026-05-06T06:42:04.265653+00:00"
+      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.osDiskSizeGB$": {
-      "matchCount": 31,
+      "matchCount": 32,
       "firstMatched": "2026-01-28T07:36:35.396763+00:00",
-      "lastMatched": "2026-05-06T06:42:04.265653+00:00"
+      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.upgradeSettings$": {
-      "matchCount": 31,
+      "matchCount": 32,
       "firstMatched": "2026-01-28T07:36:35.396763+00:00",
-      "lastMatched": "2026-05-06T06:42:04.265653+00:00"
+      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.osSKU$": {
       "matchCount": 30,
@@ -81,44 +81,44 @@
       "lastMatched": "2026-03-18T04:33:16.070546+00:00"
     },
     "Microsoft.ContainerRegistry/registries:auto_managed_patterns:^roleAssignmentMode$": {
-      "matchCount": 31,
+      "matchCount": 32,
       "firstMatched": "2026-01-28T07:36:35.396763+00:00",
-      "lastMatched": "2026-05-06T06:42:04.265653+00:00"
+      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.securityProfile$": {
-      "matchCount": 31,
+      "matchCount": 32,
       "firstMatched": "2026-01-28T07:36:35.396763+00:00",
-      "lastMatched": "2026-05-06T06:42:04.265653+00:00"
+      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.osDiskType$": {
-      "matchCount": 31,
+      "matchCount": 32,
       "firstMatched": "2026-01-28T07:36:35.396763+00:00",
-      "lastMatched": "2026-05-06T06:42:04.265653+00:00"
+      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^autoScalerProfile\\.skip-nodes-with-local-storage$": {
-      "matchCount": 31,
+      "matchCount": 32,
       "firstMatched": "2026-01-28T07:36:35.396763+00:00",
-      "lastMatched": "2026-05-06T06:42:04.265653+00:00"
+      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^securityProfile\\.defender$": {
-      "matchCount": 30,
+      "matchCount": 31,
       "firstMatched": "2026-01-28T07:40:32.040732+00:00",
-      "lastMatched": "2026-05-06T06:42:04.265653+00:00"
+      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.count$": {
-      "matchCount": 30,
+      "matchCount": 31,
       "firstMatched": "2026-01-28T07:40:32.040732+00:00",
-      "lastMatched": "2026-05-06T06:42:04.265653+00:00"
+      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^storageProfile$": {
-      "matchCount": 30,
+      "matchCount": 31,
       "firstMatched": "2026-01-28T07:40:32.040732+00:00",
-      "lastMatched": "2026-05-06T06:42:04.265653+00:00"
+      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^addonProfiles$": {
-      "matchCount": 30,
+      "matchCount": 31,
       "firstMatched": "2026-01-28T07:40:32.040732+00:00",
-      "lastMatched": "2026-05-06T06:42:04.265653+00:00"
+      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^securityProfile\\.imageCleaner$": {
       "matchCount": 29,
@@ -126,24 +126,24 @@
       "lastMatched": "2026-03-18T04:33:16.070546+00:00"
     },
     "Microsoft.Network/virtualNetworks:auto_managed_patterns:^privateEndpointVNetPolicies$": {
-      "matchCount": 30,
+      "matchCount": 31,
       "firstMatched": "2026-01-28T07:40:32.040732+00:00",
-      "lastMatched": "2026-05-06T06:42:04.265653+00:00"
+      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^windowsProfile$": {
-      "matchCount": 30,
+      "matchCount": 31,
       "firstMatched": "2026-01-28T07:40:32.040732+00:00",
-      "lastMatched": "2026-05-06T06:42:04.265653+00:00"
+      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^serviceMeshProfile$": {
-      "matchCount": 21,
+      "matchCount": 22,
       "firstMatched": "2026-02-02T09:46:15.864264+00:00",
-      "lastMatched": "2026-05-06T06:42:04.265653+00:00"
+      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
     },
     "Microsoft.ContainerRegistry/registries:auto_managed_patterns:^networkRuleBypassAllowedForTasks$": {
-      "matchCount": 18,
+      "matchCount": 19,
       "firstMatched": "2026-03-04T00:59:09.421623+00:00",
-      "lastMatched": "2026-05-06T06:42:04.265653+00:00"
+      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
     },
     "Microsoft.Network/publicIPAddresses:auto_managed_patterns:^ipTags$": {
       "matchCount": 15,
@@ -151,14 +151,14 @@
       "lastMatched": "2026-05-06T06:42:04.265653+00:00"
     },
     "Microsoft.Network/virtualNetworks/subnets/providers/roleAssignments:auto_managed_patterns:^principalId$": {
-      "matchCount": 17,
+      "matchCount": 18,
       "firstMatched": "2026-03-04T01:01:54.287895+00:00",
-      "lastMatched": "2026-05-06T06:42:04.265653+00:00"
+      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
     },
     "Microsoft.Network/virtualNetworks/subnets/providers/roleAssignments:auto_managed_patterns:^principalType$": {
-      "matchCount": 17,
+      "matchCount": 18,
       "firstMatched": "2026-03-04T01:01:54.287895+00:00",
-      "lastMatched": "2026-05-06T06:42:04.265653+00:00"
+      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
     },
     "Microsoft.ContainerService/managedClusters:custom_patterns:^kubernetesVersion$": {
       "matchCount": 3,
@@ -166,9 +166,9 @@
       "lastMatched": "2026-03-16T05:54:32.682583+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^networkProfile\\.advancedNetworking\\.performance$": {
-      "matchCount": 2,
+      "matchCount": 3,
       "firstMatched": "2026-03-18T04:33:16.070546+00:00",
-      "lastMatched": "2026-05-06T06:42:04.265653+00:00"
+      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.upgradeSettingsBlueGreen$": {
       "matchCount": 1,
@@ -176,14 +176,14 @@
       "lastMatched": "2026-03-18T04:33:16.070546+00:00"
     },
     "Microsoft.Chaos/experiments:auto_managed_patterns:^tags$": {
-      "matchCount": 2,
+      "matchCount": 3,
       "firstMatched": "2026-03-18T04:33:16.070546+00:00",
-      "lastMatched": "2026-05-06T06:42:04.265653+00:00"
+      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
     },
     "Microsoft.Chaos/experiments:auto_managed_patterns:^steps\\.\\d+\\.branches\\.\\d+\\.actions\\.\\d+\\.parameters\\.\\d+\\.value$": {
-      "matchCount": 2,
+      "matchCount": 3,
       "firstMatched": "2026-03-18T04:33:16.070546+00:00",
-      "lastMatched": "2026-05-06T06:42:04.265653+00:00"
+      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.upgradeStrategy$": {
       "matchCount": 1,
@@ -191,10 +191,10 @@
       "lastMatched": "2026-03-18T04:33:16.070546+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^ingressProfile\\.webAppRouting\\.defaultDomain$": {
-      "matchCount": 2,
+      "matchCount": 3,
       "firstMatched": "2026-03-18T04:33:16.070546+00:00",
-      "lastMatched": "2026-05-06T06:42:04.265653+00:00"
+      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
     }
   },
-  "lastRun": "2026-05-06T06:42:34.814203+00:00"
+  "lastRun": "2026-05-10T11:33:58.929649+00:00"
 }

--- a/.github/skills/bicep-what-if-analysis/scripts/tests/test_what_if_analyzer.py
+++ b/.github/skills/bicep-what-if-analysis/scripts/tests/test_what_if_analyzer.py
@@ -10,7 +10,6 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
-from typing import Any
 
 # テスト対象モジュールのパスを追加
 sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -372,6 +371,60 @@ class TestGetReferenceInfo(unittest.TestCase):
 
 class TestFormatAzdStyleOutput(unittest.TestCase):
     """format_azd_style_output のテスト"""
+
+    def test_filtered_prometheus_rule_group_modify_is_visible(self) -> None:
+        """filtered_resource_types 対象でも Modify は text 出力に表示する"""
+        output_data = {
+            "changes": [
+                {
+                    "operation": "Modify",
+                    "resourceId": (
+                        "/subscriptions/test-sub/resourceGroups/test-rg/providers/"
+                        "Microsoft.AlertsManagement/prometheusRuleGroups/"
+                        "app-operational-alerts"
+                    ),
+                    "resourceType": "Microsoft.AlertsManagement/prometheusRuleGroups",
+                    "resourceName": "app-operational-alerts",
+                    "propertyChanges": [
+                        {
+                            "changeType": "Modify",
+                            "path": "properties.rules.0.expression",
+                            "referenceInfo": "❓ 未分類。確認推奨",
+                        }
+                    ],
+                    "likelyFalsePositive": False,
+                }
+            ]
+        }
+
+        result = format_azd_style_output(output_data)
+
+        self.assertIn("Modify", result)
+        self.assertIn("Prometheus Rule Group", result)
+        self.assertIn("app-operational-alerts", result)
+        self.assertIn("properties.rules.0.expression", result)
+
+    def test_filtered_prometheus_rule_group_nochange_is_hidden(self) -> None:
+        """filtered_resource_types 対象の NoChange は引き続き非表示にする"""
+        output_data = {
+            "changes": [
+                {
+                    "operation": "NoChange",
+                    "resourceId": (
+                        "/subscriptions/test-sub/resourceGroups/test-rg/providers/"
+                        "Microsoft.AlertsManagement/prometheusRuleGroups/"
+                        "app-operational-alerts"
+                    ),
+                    "resourceType": "Microsoft.AlertsManagement/prometheusRuleGroups",
+                    "resourceName": "app-operational-alerts",
+                    "propertyChanges": [],
+                }
+            ]
+        }
+
+        result = format_azd_style_output(output_data)
+
+        self.assertEqual(result.strip(), "Resources:")
 
     def test_filters_known_acr_acrpull_unsupported(self) -> None:
         """既知の ACR AcrPull Unsupported だけを非表示にする"""

--- a/.github/skills/bicep-what-if-analysis/scripts/what_if_analyzer.py
+++ b/.github/skills/bicep-what-if-analysis/scripts/what_if_analyzer.py
@@ -1886,6 +1886,30 @@ def _extract_actual_provider_type(resource_id: str) -> str | None:
     return None
 
 
+EFFECTIVE_OPERATIONS = {"Create", "Modify", "Delete"}
+
+
+def is_effective_change(change: dict[str, Any]) -> bool:
+    """text 出力で必ず見せるべき実変更かどうかを判定する。"""
+    return change.get("operation") in EFFECTIVE_OPERATIONS
+
+
+def should_show_resource_in_text_output(change: dict[str, Any]) -> bool:
+    """
+    text 出力にリソースを表示するかどうかを判定する。
+
+    filtered_resource_types は NoChange / Ignore / Unsupported などのノイズ削減に使い、
+    Create / Modify / Delete は重要差分を隠さないよう常に表示する。
+    """
+    if is_known_acr_acrpull_unsupported(change):
+        return False
+
+    if is_effective_change(change):
+        return True
+
+    return is_main_resource(change)
+
+
 def format_azd_style_output(output_data: dict[str, Any]) -> str:
     """
     azd provision --preview 風のテキスト出力を生成する。
@@ -1910,20 +1934,27 @@ def format_azd_style_output(output_data: dict[str, Any]) -> str:
         "Delete": "Delete",
     }
 
-    # 主要リソースのみフィルタリング
-    main_resources = [
+    # text 出力対象をフィルタリング
+    display_candidates = [
         c
         for c in output_data["changes"]
-        if is_main_resource(c)
+        if should_show_resource_in_text_output(c)
     ]
 
     # Create false positive をフィルタ（件数は記録）
     false_positive_count = sum(
-        1 for c in main_resources if c.get("likelyFalsePositive", False)
+        1 for c in display_candidates if c.get("likelyFalsePositive", False)
     )
     visible_resources = [
-        c for c in main_resources if not c.get("likelyFalsePositive", False)
+        c for c in display_candidates if not c.get("likelyFalsePositive", False)
     ]
+    hidden_effective_count = sum(
+        1
+        for c in output_data["changes"]
+        if is_effective_change(c)
+        and not should_show_resource_in_text_output(c)
+        and not c.get("likelyFalsePositive", False)
+    )
 
     # 最大幅を計算（整列用）
     max_op_len = 8  # "Modify" など
@@ -1974,6 +2005,12 @@ def format_azd_style_output(output_data: dict[str, Any]) -> str:
         lines.append(
             f"  ({false_positive_count} 件の Create を非表示: "
             "ARM what-if の既知制限による false positive)"
+        )
+
+    if hidden_effective_count > 0:
+        lines.append(
+            f"  ⚠️ {hidden_effective_count} 件の Create/Modify/Delete が "
+            "text 出力で非表示です。--format json で確認してください。"
         )
 
     return "\n".join(lines)


### PR DESCRIPTION
`bicep-what-if-analysis` の text 出力で、`filtered_resource_types` に含まれるリソースの重要な `Modify` 差分が隠れる問題を修正します。text 出力だけを見ても、デプロイに影響する `Create` / `Modify` / `Delete` を見落とさないようにします。

## Summary

- `Create` / `Modify` / `Delete` を text 出力では常に表示する判定を追加
- `NoChange` / `Ignore` / `Unsupported` などのノイズ抑制には既存フィルタを継続利用
- Prometheus Rule Group の `Modify` が表示される回帰テストを追加
- what-if 実行に伴う pattern stats を更新

## Validation

- `uv run .github/skills/bicep-what-if-analysis/scripts/tests/test_what_if_analyzer.py`
- `uv --directory src run ruff check ../.github/skills/bicep-what-if-analysis/scripts/what_if_analyzer.py ../.github/skills/bicep-what-if-analysis/scripts/tests/test_what_if_analyzer.py --select E,F --ignore E501`
- `uv --directory src run ty check ../.github/skills/bicep-what-if-analysis/scripts/what_if_analyzer.py`

Fixes #136