### PR TITLE
chore: migrate Copilot CLI MCP config to .mcp.json and upgrade gh-aw to v0.72.1

### DIFF
--- a/.github/aw/actions-lock.json
+++ b/.github/aw/actions-lock.json
@@ -25,10 +25,10 @@
       "version": "v7.0.1",
       "sha": "043fb46d1a93c77aae656e7c1c64a875d1fc6a0a"
     },
-    "github/gh-aw-actions/setup@v0.71.1": {
+    "github/gh-aw-actions/setup@v0.72.1": {
       "repo": "github/gh-aw-actions/setup",
-      "version": "v0.71.1",
-      "sha": "239aec45b78c8799417efdd5bc6d8cc036629ec1"
+      "version": "v0.72.1",
+      "sha": "bc56a0cad2f450c562810785ef38649c04db812a"
     },
     "github/gh-aw/actions/setup@v0.71.1": {
       "repo": "github/gh-aw/actions/setup",

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "github-agentic-workflows": {
+      "type": "stdio",
+      "command": "gh",
+      "args": [
+        "aw",
+        "mcp-server"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## 概要

Copilot CLI が `.vscode/mcp.json` のサポートを廃止したことに伴うエラーメッセージ:

> Copilot CLI's incomplete support for .vscode/mcp.json has been removed. See https://gh.io/copilotcli-mcpmigrate to migrate to .mcp.json

の解消と、ついでに古くなっていた `gh-aw` 拡張のアップグレードを行います。

## 変更内容

### 1. MCP 設定の移行 (`966f814`)

- `.vscode/mcp.json` → **`.mcp.json`** に移行（ワークスペースルート直下）。
- top-level key を VS Code 由来の `servers` から、Copilot CLI 仕様の **`mcpServers`** に変更。
- `gh aw mcp-server` を起動するだけのシンプルな構成でシークレットを含まないため、`.gitignore` には追加せずチームで共有する追跡対象とする。

設定先の根拠 (`copilot mcp --help`):
```
Configuration is loaded from multiple sources:
  User       ~/.copilot/mcp-config.json
  Workspace  .mcp.json
  Plugin     Installed plugins with MCP servers
```

### 2. `gh-aw` 拡張のアップグレード (`2486fc2`)

- `gh-aw` を `v0.68.3` → **`v0.72.1`**（安定版最新）にアップグレード。
  - 課金バグで retire された範囲 `v0.68.4 ~ v0.71.3` を回避。
  - `v0.73.x` 以降は pre-release のため対象外。
- `gh aw validate` により `actions-lock.json` が自動更新され、`github/gh-aw-actions/setup` の SHA pin が `v0.71.1` → `v0.72.1` に整合された。

## 検証

- `copilot mcp list` で `github-agentic-workflows (local)` が Workspace servers として読まれることを確認。
- `gh aw status` / `gh aw validate` が新版 `v0.72.1` で正常動作することを確認（既存ワークフロー `aks-updates-analyzer` で確認）。
- `gh aw validate` で 1 件の warning (`'www.microsoft.com'` → ecosystem identifier `'dotnet'` 推奨) が出るが、これは v0.72 の strict mode で新規追加された推奨事項で機能影響なし。本 PR の対象外。

## 注意

- 現在実行中の `gh aw mcp-server` プロセスは古いバージョン (v0.68.3) のバイナリで動作中。Copilot CLI を再起動すると新版 (v0.72.1) で再接続される。
- VS Code Copilot Chat や Copilot Coding Agent も使用する場合は、それぞれ別の MCP 設定パスが必要（VS Code: `.vscode/mcp.json` / Coding Agent: GitHub.com のリポジトリ Settings UI）。本 PR では Copilot CLI 用のみ整備する。
