### PR TITLE
fix: reduce azd deployment warnings

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -117,7 +117,7 @@ azd provision base --preview
 azd provision sli --preview
 ```
 
-`azd up` 中に `DeploymentNotFound` が出ても、ARM 上の deployment が `Succeeded` で残るケースがあります。その場合は `azd up` を再実行してください。詳細は [docs/workarounds.md §D-2](workarounds.md#d-2-azd-の-subscription-scope-deployment-polling-が散発的に-deploymentnotfound-を返す) を参照してください。
+`azd up` 中に `DeploymentNotFound` が出ても、ARM 上の deployment が `Succeeded` で残るケースがあります。その場合は `azd env refresh <env> --no-prompt` で env outputs を同期してから、`azd up --no-prompt` を再実行してください。詳細は [docs/workarounds.md §D-2](workarounds.md#d-2-azd-の-subscription-scope-deployment-polling-が散発的に-deploymentnotfound-を返す) を参照してください。
 
 ## ローカル開発
 

--- a/docs/workarounds.md
+++ b/docs/workarounds.md
@@ -122,9 +122,9 @@ ID は履歴追跡用に固定する。削除済み ID は再利用しない。
 - **理由**: 未確定。ARM の deployment record が一時的に GET で見えないウィンドウがあるように見えるが、根本原因は未特定。観測事実の報告として upstream issue [Azure/azure-dev#8064](https://github.com/Azure/azure-dev/issues/8064) を起票済み。
 - **場所**: `scripts/cleanup-azure-monitor-sli-resources.py`、ADR-009
 - **構造的対処 (down 側のみ・実装済み)**: `predown` hook が Service Group scope SLI / Service Group / OTLP DCRA / SLI layer deployment record / base RG / base layer deployment record を順に削除し、`azd down` の Destroy 経路を両 layer で graceful skip path に短絡する。これにより down 側の `voidSubscriptionDeploymentState` を呼ばない。
-- **対処できない範囲 (up 側)**: `azd up` の通常 deployment polling は azd 側で起こるため、リポジトリ側からは予防できない。再現した場合は `azd up` を再実行する。
+- **対処できない範囲 (up 側)**: `azd up` の通常 deployment polling は azd 側で起こるため、リポジトリ側からは予防できない。再現した場合は ARM 上の該当 subscription deployment が `Succeeded` か確認し、成功していれば `azd env refresh <env> --no-prompt` で env outputs を同期してから `azd up --no-prompt` を再実行する。
 - **確認方法**: 一時環境の削除後、`az deployment sub list` で該当 env の deployment record が残っていないことを確認する。
-- **最終確認**: 2026-05-17 の検証中にも `azd provision base` で `DeploymentNotFound` が再現し、ARM deployment は後から `Succeeded` / `Failed` に到達した。削除不可。
+- **最終確認**: 2026-05-18、`eval` 環境の `azd up` で `provision sli` が `DeploymentNotFound` を返したが、ARM 上の `eval-sli-1779095707` は `Succeeded`。`azd env refresh eval --no-prompt` 後の `azd up --no-prompt` 再実行で成功。削除不可。
 
 ### D-4. Azure Monitor SLI Metric Alert (Portal 型) の動作仕様が未公開
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -447,15 +447,15 @@ module chaosRoleAssignments './modules/chaos/role-assignments.bicep' = if (enabl
   scope: resourceGroup
   params: {
     aksId: aksCluster.outputs.aksId
-    podChaosPrincipalId: chaosExperiments.outputs.podChaosPrincipalId
-    networkChaosPrincipalId: chaosExperiments.outputs.networkChaosPrincipalId
-    networkChaosLossPrincipalId: chaosExperiments.outputs.networkChaosLossPrincipalId
-    stressChaosPrincipalId: chaosExperiments.outputs.stressChaosPrincipalId
-    ioChaosPrincipalId: chaosExperiments.outputs.ioChaosPrincipalId
-    timeChaosPrincipalId: chaosExperiments.outputs.timeChaosPrincipalId
-    kernelChaosPrincipalId: chaosExperiments.outputs.kernelChaosPrincipalId
-    httpChaosPrincipalId: chaosExperiments.outputs.httpChaosPrincipalId
-    dnsChaosPrincipalId: chaosExperiments.outputs.dnsChaosPrincipalId
+    podChaosPrincipalId: chaosExperiments!.outputs.podChaosPrincipalId
+    networkChaosPrincipalId: chaosExperiments!.outputs.networkChaosPrincipalId
+    networkChaosLossPrincipalId: chaosExperiments!.outputs.networkChaosLossPrincipalId
+    stressChaosPrincipalId: chaosExperiments!.outputs.stressChaosPrincipalId
+    ioChaosPrincipalId: chaosExperiments!.outputs.ioChaosPrincipalId
+    timeChaosPrincipalId: chaosExperiments!.outputs.timeChaosPrincipalId
+    kernelChaosPrincipalId: chaosExperiments!.outputs.kernelChaosPrincipalId
+    httpChaosPrincipalId: chaosExperiments!.outputs.httpChaosPrincipalId
+    dnsChaosPrincipalId: chaosExperiments!.outputs.dnsChaosPrincipalId
   }
 }
 

--- a/infra/modules/chaos/experiments.bicep
+++ b/infra/modules/chaos/experiments.bicep
@@ -58,6 +58,8 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2026-03-02-previ
   scope: resourceGroup()
 }
 
+// Azure Chaos Studio documents this AKS Chaos Mesh target type name. ARM validation
+// may warn about the reserved word, but changing the target name breaks capability binding.
 resource chaosTarget 'Microsoft.Chaos/targets@2025-01-01' = {
   name: 'microsoft-azurekubernetesservicechaosmesh'
   scope: aksCluster


### PR DESCRIPTION
## 背景

`azd up` の eval 更新時に、Bicep の conditional module output 警告と Chaos Studio target 名の reserved word 警告が出ていました。また、`DeploymentNotFound` が発生しても ARM 側では deployment が `Succeeded` になっているケースがあり、復旧手順を明確にしておく必要がありました。

## 変更内容

- conditional deployment の `chaosExperiments` outputs 参照に null-forgiving access を使い、`infra/main.bicep` の BCP318 警告を解消
- Azure Chaos Studio が要求する AKS Chaos Mesh target type 名について、reserved word 警告が出ても名前を変えない理由を inline comment で明記
- `DeploymentNotFound` 発生時は ARM deployment の成功を確認し、`azd env refresh <env> --no-prompt` 後に `azd up --no-prompt` を再実行する手順へ docs を更新

## 検証

- `az bicep build --file infra/main.bicep`
- `az bicep build --file infra/sli/main.bicep`
- `git diff --check`

## 注意点

Chaos Studio target 名の reserved word 警告自体は Azure 側の target type 名に由来するため、リポジトリ側では名前を変更せず、仕様依存の警告として扱います。