### PR TITLE
chore: upgrade AKS to 1.34 and document azd preflight workaround

### DIFF
--- a/.github/skills/bicep-what-if-analysis/scripts/patterns/noise_patterns.json
+++ b/.github/skills/bicep-what-if-analysis/scripts/patterns/noise_patterns.json
@@ -64,7 +64,10 @@
                 {"pattern": "^securityProfile\\.imageCleaner$", "description": "イメージクリーナーは Azure のデフォルト設定"},
                 {"pattern": "^windowsProfile$", "description": "Windows プロファイルは Linux クラスターでも Azure がデフォルト設定"},
                 {"pattern": "^storageProfile$", "description": "ストレージプロファイル（CSI ドライバー）は Azure が自動設定"},
-                {"pattern": "^serviceMeshProfile$", "description": "サービスメッシュプロファイルは Bicep 未定義時に Azure が Disabled をデフォルト設定"}
+                {"pattern": "^serviceMeshProfile$", "description": "サービスメッシュプロファイルは Bicep 未定義時に Azure が Disabled をデフォルト設定"},
+                {"pattern": "^azureMonitorProfile\\.metrics\\.controlPlane$", "description": "Managed Prometheus 有効時に Azure がコントロールプレーン scrape 設定を自動付与"},
+                {"pattern": "^healthMonitorProfile$", "description": "Health monitor profile は preview 機能で Azure が自動有効化"},
+                {"pattern": "^nodeDisruptionProfile$", "description": "Node disruption profile は Azure が自動構成"}
             ],
             "custom_patterns": [
                 {"pattern": "^kubernetesVersion$", "description": "K8s バージョン要確認（マイナーまで一致ならOK、パッチは AKS 自動適用）"},
@@ -157,6 +160,156 @@
             ],
             "custom_patterns": [],
             "known_defaults": []
+        },
+        "Microsoft.Management/serviceGroups/providers/slis": {
+            "readonly_patterns": [
+                "^destinationMetrics$",
+                "^executionState$",
+                "^streamingRuleId$",
+                "^streamingRuleLastUpdatedTimestamp$"
+            ],
+            "auto_managed_patterns": [],
+            "custom_patterns": [],
+            "known_defaults": []
+        },
+        "Microsoft.Cache/redisEnterprise/providers/serviceGroupMember": {
+            "readonly_patterns": ["^metadata$", "^originInformation$", "^sourceId$", "^targetTenant$"],
+            "auto_managed_patterns": [], "custom_patterns": [], "known_defaults": []
+        },
+        "Microsoft.ContainerRegistry/registries/providers/serviceGroupMember": {
+            "readonly_patterns": ["^metadata$", "^originInformation$", "^sourceId$", "^targetTenant$"],
+            "auto_managed_patterns": [], "custom_patterns": [], "known_defaults": []
+        },
+        "Microsoft.ContainerService/managedClusters/providers/serviceGroupMember": {
+            "readonly_patterns": ["^metadata$", "^originInformation$", "^sourceId$", "^targetTenant$"],
+            "auto_managed_patterns": [], "custom_patterns": [], "known_defaults": []
+        },
+        "Microsoft.Insights/components/providers/serviceGroupMember": {
+            "readonly_patterns": ["^metadata$", "^originInformation$", "^sourceId$", "^targetTenant$"],
+            "auto_managed_patterns": [], "custom_patterns": [], "known_defaults": []
+        },
+        "Microsoft.Monitor/accounts/providers/serviceGroupMember": {
+            "readonly_patterns": ["^metadata$", "^originInformation$", "^sourceId$", "^targetTenant$"],
+            "auto_managed_patterns": [], "custom_patterns": [], "known_defaults": []
+        },
+        "Microsoft.OperationalInsights/workspaces/providers/serviceGroupMember": {
+            "readonly_patterns": ["^metadata$", "^originInformation$", "^sourceId$", "^targetTenant$"],
+            "auto_managed_patterns": [], "custom_patterns": [], "known_defaults": []
+        },
+        "Microsoft.Cache/redisEnterprise/databases": {
+            "readonly_patterns": [],
+            "auto_managed_patterns": [
+                {"pattern": "^redisVersion$", "description": "Redis エンジンバージョンは Azure が自動採用する最新マイナーで上書きされる"}
+            ],
+            "custom_patterns": [], "known_defaults": []
+        },
+        "Microsoft.ContainerService/fleets": {
+            "readonly_patterns": ["^properties$"],
+            "auto_managed_patterns": [], "custom_patterns": [], "known_defaults": []
+        },
+        "Microsoft.ContainerService/fleets/autoUpgradeProfiles": {
+            "readonly_patterns": ["^autoUpgradeProfileStatus$"],
+            "auto_managed_patterns": [
+                {"pattern": "^longTermSupport$", "description": "longTermSupport は Bicep 未指定時に Azure が false をデフォルト設定"}
+            ],
+            "custom_patterns": [], "known_defaults": []
+        },
+        "Microsoft.ContainerService/fleets/members": {
+            "readonly_patterns": ["^status$"],
+            "auto_managed_patterns": [
+                {"pattern": "^labels$", "description": "Fleet member labels は Bicep 未指定時に Azure が null を設定"}
+            ],
+            "custom_patterns": [], "known_defaults": []
+        },
+        "Microsoft.ContainerService/fleets/updateStrategies": {
+            "readonly_patterns": [],
+            "auto_managed_patterns": [
+                {"pattern": "^strategy\\.stages\\.\\d+\\.afterStageWaitInSeconds$", "description": "afterStageWaitInSeconds は Bicep 未指定時に Azure が 0 をデフォルト設定"}
+            ],
+            "custom_patterns": [], "known_defaults": []
+        },
+        "Microsoft.ManagedIdentity/userAssignedIdentities": {
+            "readonly_patterns": ["^properties$"],
+            "auto_managed_patterns": [], "custom_patterns": [], "known_defaults": []
+        },
+        "Microsoft.Monitor/accounts": {
+            "readonly_patterns": ["^properties$"],
+            "auto_managed_patterns": [], "custom_patterns": [], "known_defaults": []
+        },
+        "Microsoft.Insights/dataCollectionEndpoints": {
+            "readonly_patterns": ["^properties$"],
+            "auto_managed_patterns": [], "custom_patterns": [], "known_defaults": []
+        },
+        "Microsoft.Network/privateDnsZones/virtualNetworkLinks": {
+            "readonly_patterns": [],
+            "auto_managed_patterns": [
+                {"pattern": "^resolutionPolicy$", "description": "resolutionPolicy は Bicep 未指定時に Azure が Default を自動設定"}
+            ],
+            "custom_patterns": [], "known_defaults": []
+        },
+        "Microsoft.Network/privateEndpoints/privateDnsZoneGroups": {
+            "readonly_patterns": [
+                "^privateDnsZoneConfigs\\.\\d+\\.etag$",
+                "^privateDnsZoneConfigs\\.\\d+\\.id$",
+                "^privateDnsZoneConfigs\\.\\d+\\.type$",
+                "^privateDnsZoneConfigs\\.\\d+\\.properties\\.provisioningState$"
+            ],
+            "auto_managed_patterns": [], "custom_patterns": [], "known_defaults": []
+        },
+        "Microsoft.OperationalInsights/workspaces/tables": {
+            "readonly_patterns": ["^schema$"],
+            "auto_managed_patterns": [
+                {"pattern": "^retentionInDays$", "description": "テーブル retention は workspace の既定値を Azure が自動継承"},
+                {"pattern": "^totalRetentionInDays$", "description": "総 retention は workspace の既定値を Azure が自動継承"}
+            ],
+            "custom_patterns": [], "known_defaults": []
+        },
+        "Microsoft.Authorization/roleAssignments": {
+            "readonly_patterns": [],
+            "auto_managed_patterns": [
+                {"pattern": "^principalId$", "description": "マネージド ID の principalId は reference() 解決時に what-if がノイズ検出"},
+                {"pattern": "^principalType$", "description": "principalType は ARM what-if が null と指定値の差分をノイズ検出"}
+            ],
+            "custom_patterns": [], "known_defaults": []
+        },
+        "Microsoft.Insights/diagnosticSettings": {
+            "readonly_patterns": [],
+            "auto_managed_patterns": [
+                {"pattern": "^logs\\.\\d+$", "description": "AKS 旧スキーマで Azure が自動付与した追加 category (kube-audit/fleet-member-*/karpenter-events 等) は enabled=false 状態でノイズ"},
+                {"pattern": "^logs\\.\\d+\\.retentionPolicy\\.days$", "description": "retentionPolicy.days は deprecated フィールドで Azure が 0 を自動付与"},
+                {"pattern": "^metrics$", "description": "Bicep 未指定の metrics ブロックは Azure が AllMetrics(enabled=false) を自動付与"}
+            ],
+            "custom_patterns": [], "known_defaults": []
+        },
+        "Microsoft.ContainerService/managedClusters/providers/diagnosticSettings": {
+            "readonly_patterns": [],
+            "auto_managed_patterns": [
+                {"pattern": "^logs\\.\\d+$", "description": "AKS 旧スキーマで Azure が自動付与した追加 category (kube-audit/fleet-member-*/karpenter-events 等) は enabled=false 状態でノイズ"},
+                {"pattern": "^logs\\.\\d+\\.retentionPolicy\\.days$", "description": "retentionPolicy.days は deprecated フィールドで Azure が 0 を自動付与"},
+                {"pattern": "^metrics$", "description": "Bicep 未指定の metrics ブロックは Azure が AllMetrics(enabled=false) を自動付与"}
+            ],
+            "custom_patterns": [], "known_defaults": []
+        },
+        "Microsoft.Insights/scheduledQueryRules": {
+            "readonly_patterns": [],
+            "auto_managed_patterns": [
+                {"pattern": "^windowSize$", "description": "ISO8601 (PT60M) と TimeSpan (01:00:00) の表記差で what-if がノイズ検出（値は等価）"}
+            ],
+            "custom_patterns": [], "known_defaults": []
+        },
+        "Microsoft.Insights/dataCollectionRuleAssociations": {
+            "readonly_patterns": [],
+            "auto_managed_patterns": [
+                {"pattern": "^dataCollectionRuleId$", "description": "App Insights managed DCR ID は reference() 解決時に what-if がノイズ検出（要 drift 照合）"}
+            ],
+            "custom_patterns": [], "known_defaults": []
+        },
+        "Microsoft.ContainerService/managedClusters/providers/dataCollectionRuleAssociations": {
+            "readonly_patterns": [],
+            "auto_managed_patterns": [
+                {"pattern": "^dataCollectionRuleId$", "description": "App Insights managed DCR ID は reference() 解決時に what-if がノイズ検出（要 drift 照合）"}
+            ],
+            "custom_patterns": [], "known_defaults": []
         }
     }
 }

--- a/.github/skills/bicep-what-if-analysis/scripts/patterns/pattern_stats.json
+++ b/.github/skills/bicep-what-if-analysis/scripts/patterns/pattern_stats.json
@@ -1,39 +1,39 @@
 {
   "patterns": {
     "Microsoft.Network/virtualNetworks:custom_patterns:^subnets\\..*\\.properties\\.networkSecurityGroup$": {
-      "matchCount": 34,
+      "matchCount": 40,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
+      "lastMatched": "2026-05-18T23:19:10.964598+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^identityProfile$": {
-      "matchCount": 37,
+      "matchCount": 43,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
+      "lastMatched": "2026-05-18T23:19:10.964598+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.powerState$": {
-      "matchCount": 37,
+      "matchCount": 43,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
+      "lastMatched": "2026-05-18T23:19:10.964598+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^aadProfile\\.tenantID$": {
-      "matchCount": 37,
+      "matchCount": 43,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
+      "lastMatched": "2026-05-18T23:19:10.964598+00:00"
     },
     "Microsoft.Network/publicIPAddresses:auto_managed_patterns:^ddosSettings$": {
-      "matchCount": 37,
+      "matchCount": 43,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
+      "lastMatched": "2026-05-18T23:19:10.964598+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^servicePrincipalProfile$": {
-      "matchCount": 37,
+      "matchCount": 43,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
+      "lastMatched": "2026-05-18T23:19:10.964598+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^controlPlanePluginProfiles$": {
-      "matchCount": 37,
+      "matchCount": 43,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
+      "lastMatched": "2026-05-18T23:19:10.964598+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^ingressProfile\\.webAppRouting\\.nginx$": {
       "matchCount": 35,
@@ -41,39 +41,39 @@
       "lastMatched": "2026-03-18T04:33:16.070546+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^nodeProvisioningProfile$": {
-      "matchCount": 37,
+      "matchCount": 43,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
+      "lastMatched": "2026-05-18T23:19:10.964598+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^networkProfile\\.advancedNetworking\\.security\\.transitEncryption$": {
-      "matchCount": 36,
+      "matchCount": 42,
       "firstMatched": "2026-01-28T07:27:16.893220+00:00",
-      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
+      "lastMatched": "2026-05-18T23:19:10.964598+00:00"
     },
     "Microsoft.ContainerService/managedClusters:custom_patterns:^agentPoolProfiles\\[\\d+\\]\\.orchestratorVersion$": {
-      "matchCount": 35,
+      "matchCount": 41,
       "firstMatched": "2026-01-28T07:27:16.893220+00:00",
-      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
+      "lastMatched": "2026-05-18T23:19:10.964598+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^networkProfile\\.podCidrs$": {
-      "matchCount": 36,
+      "matchCount": 42,
       "firstMatched": "2026-01-28T07:27:16.893220+00:00",
-      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
+      "lastMatched": "2026-05-18T23:19:10.964598+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^networkProfile\\.serviceCidrs$": {
-      "matchCount": 36,
+      "matchCount": 42,
       "firstMatched": "2026-01-28T07:27:16.893220+00:00",
-      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
+      "lastMatched": "2026-05-18T23:19:10.964598+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.osDiskSizeGB$": {
-      "matchCount": 32,
+      "matchCount": 38,
       "firstMatched": "2026-01-28T07:36:35.396763+00:00",
-      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
+      "lastMatched": "2026-05-18T23:19:10.964598+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.upgradeSettings$": {
-      "matchCount": 32,
+      "matchCount": 38,
       "firstMatched": "2026-01-28T07:36:35.396763+00:00",
-      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
+      "lastMatched": "2026-05-18T23:19:10.964598+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.osSKU$": {
       "matchCount": 30,
@@ -81,44 +81,44 @@
       "lastMatched": "2026-03-18T04:33:16.070546+00:00"
     },
     "Microsoft.ContainerRegistry/registries:auto_managed_patterns:^roleAssignmentMode$": {
-      "matchCount": 32,
+      "matchCount": 38,
       "firstMatched": "2026-01-28T07:36:35.396763+00:00",
-      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
+      "lastMatched": "2026-05-18T23:19:10.964598+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.securityProfile$": {
-      "matchCount": 32,
+      "matchCount": 38,
       "firstMatched": "2026-01-28T07:36:35.396763+00:00",
-      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
+      "lastMatched": "2026-05-18T23:19:10.964598+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.osDiskType$": {
-      "matchCount": 32,
+      "matchCount": 38,
       "firstMatched": "2026-01-28T07:36:35.396763+00:00",
-      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
+      "lastMatched": "2026-05-18T23:19:10.964598+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^autoScalerProfile\\.skip-nodes-with-local-storage$": {
-      "matchCount": 32,
+      "matchCount": 38,
       "firstMatched": "2026-01-28T07:36:35.396763+00:00",
-      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
+      "lastMatched": "2026-05-18T23:19:10.964598+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^securityProfile\\.defender$": {
-      "matchCount": 31,
+      "matchCount": 37,
       "firstMatched": "2026-01-28T07:40:32.040732+00:00",
-      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
+      "lastMatched": "2026-05-18T23:19:10.964598+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.count$": {
-      "matchCount": 31,
+      "matchCount": 37,
       "firstMatched": "2026-01-28T07:40:32.040732+00:00",
-      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
+      "lastMatched": "2026-05-18T23:19:10.964598+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^storageProfile$": {
-      "matchCount": 31,
+      "matchCount": 37,
       "firstMatched": "2026-01-28T07:40:32.040732+00:00",
-      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
+      "lastMatched": "2026-05-18T23:19:10.964598+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^addonProfiles$": {
-      "matchCount": 31,
+      "matchCount": 37,
       "firstMatched": "2026-01-28T07:40:32.040732+00:00",
-      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
+      "lastMatched": "2026-05-18T23:19:10.964598+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^securityProfile\\.imageCleaner$": {
       "matchCount": 29,
@@ -126,24 +126,24 @@
       "lastMatched": "2026-03-18T04:33:16.070546+00:00"
     },
     "Microsoft.Network/virtualNetworks:auto_managed_patterns:^privateEndpointVNetPolicies$": {
-      "matchCount": 31,
+      "matchCount": 37,
       "firstMatched": "2026-01-28T07:40:32.040732+00:00",
-      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
+      "lastMatched": "2026-05-18T23:19:10.964598+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^windowsProfile$": {
-      "matchCount": 31,
+      "matchCount": 37,
       "firstMatched": "2026-01-28T07:40:32.040732+00:00",
-      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
+      "lastMatched": "2026-05-18T23:19:10.964598+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^serviceMeshProfile$": {
-      "matchCount": 22,
+      "matchCount": 28,
       "firstMatched": "2026-02-02T09:46:15.864264+00:00",
-      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
+      "lastMatched": "2026-05-18T23:19:10.964598+00:00"
     },
     "Microsoft.ContainerRegistry/registries:auto_managed_patterns:^networkRuleBypassAllowedForTasks$": {
-      "matchCount": 19,
+      "matchCount": 25,
       "firstMatched": "2026-03-04T00:59:09.421623+00:00",
-      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
+      "lastMatched": "2026-05-18T23:19:10.964598+00:00"
     },
     "Microsoft.Network/publicIPAddresses:auto_managed_patterns:^ipTags$": {
       "matchCount": 15,
@@ -151,24 +151,24 @@
       "lastMatched": "2026-05-06T06:42:04.265653+00:00"
     },
     "Microsoft.Network/virtualNetworks/subnets/providers/roleAssignments:auto_managed_patterns:^principalId$": {
-      "matchCount": 18,
+      "matchCount": 24,
       "firstMatched": "2026-03-04T01:01:54.287895+00:00",
-      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
+      "lastMatched": "2026-05-18T23:19:10.964598+00:00"
     },
     "Microsoft.Network/virtualNetworks/subnets/providers/roleAssignments:auto_managed_patterns:^principalType$": {
-      "matchCount": 18,
+      "matchCount": 24,
       "firstMatched": "2026-03-04T01:01:54.287895+00:00",
-      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
+      "lastMatched": "2026-05-18T23:19:10.964598+00:00"
     },
     "Microsoft.ContainerService/managedClusters:custom_patterns:^kubernetesVersion$": {
-      "matchCount": 3,
+      "matchCount": 9,
       "firstMatched": "2026-03-16T05:33:18.741455+00:00",
-      "lastMatched": "2026-03-16T05:54:32.682583+00:00"
+      "lastMatched": "2026-05-18T23:19:10.964598+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^networkProfile\\.advancedNetworking\\.performance$": {
-      "matchCount": 3,
+      "matchCount": 9,
       "firstMatched": "2026-03-18T04:33:16.070546+00:00",
-      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
+      "lastMatched": "2026-05-18T23:19:10.964598+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.upgradeSettingsBlueGreen$": {
       "matchCount": 1,
@@ -176,14 +176,14 @@
       "lastMatched": "2026-03-18T04:33:16.070546+00:00"
     },
     "Microsoft.Chaos/experiments:auto_managed_patterns:^tags$": {
-      "matchCount": 3,
+      "matchCount": 9,
       "firstMatched": "2026-03-18T04:33:16.070546+00:00",
-      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
+      "lastMatched": "2026-05-18T23:19:10.964598+00:00"
     },
     "Microsoft.Chaos/experiments:auto_managed_patterns:^steps\\.\\d+\\.branches\\.\\d+\\.actions\\.\\d+\\.parameters\\.\\d+\\.value$": {
-      "matchCount": 3,
+      "matchCount": 9,
       "firstMatched": "2026-03-18T04:33:16.070546+00:00",
-      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
+      "lastMatched": "2026-05-18T23:19:10.964598+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.upgradeStrategy$": {
       "matchCount": 1,
@@ -191,10 +191,95 @@
       "lastMatched": "2026-03-18T04:33:16.070546+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^ingressProfile\\.webAppRouting\\.defaultDomain$": {
-      "matchCount": 3,
+      "matchCount": 9,
       "firstMatched": "2026-03-18T04:33:16.070546+00:00",
-      "lastMatched": "2026-05-10T11:33:58.929649+00:00"
+      "lastMatched": "2026-05-18T23:19:10.964598+00:00"
+    },
+    "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^nodeDisruptionProfile$": {
+      "matchCount": 5,
+      "firstMatched": "2026-05-18T23:06:29.633543+00:00",
+      "lastMatched": "2026-05-18T23:19:10.964598+00:00"
+    },
+    "Microsoft.OperationalInsights/workspaces/tables:auto_managed_patterns:^retentionInDays$": {
+      "matchCount": 5,
+      "firstMatched": "2026-05-18T23:06:29.633543+00:00",
+      "lastMatched": "2026-05-18T23:19:10.964598+00:00"
+    },
+    "Microsoft.OperationalInsights/workspaces/tables:auto_managed_patterns:^totalRetentionInDays$": {
+      "matchCount": 5,
+      "firstMatched": "2026-05-18T23:06:29.633543+00:00",
+      "lastMatched": "2026-05-18T23:19:10.964598+00:00"
+    },
+    "Microsoft.ContainerService/fleets/autoUpgradeProfiles:auto_managed_patterns:^longTermSupport$": {
+      "matchCount": 5,
+      "firstMatched": "2026-05-18T23:06:29.633543+00:00",
+      "lastMatched": "2026-05-18T23:19:10.964598+00:00"
+    },
+    "Microsoft.ContainerService/fleets/members:auto_managed_patterns:^labels$": {
+      "matchCount": 5,
+      "firstMatched": "2026-05-18T23:06:29.633543+00:00",
+      "lastMatched": "2026-05-18T23:19:10.964598+00:00"
+    },
+    "Microsoft.Cache/redisEnterprise/databases:auto_managed_patterns:^redisVersion$": {
+      "matchCount": 5,
+      "firstMatched": "2026-05-18T23:06:29.633543+00:00",
+      "lastMatched": "2026-05-18T23:19:10.964598+00:00"
+    },
+    "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^healthMonitorProfile$": {
+      "matchCount": 5,
+      "firstMatched": "2026-05-18T23:06:29.633543+00:00",
+      "lastMatched": "2026-05-18T23:19:10.964598+00:00"
+    },
+    "Microsoft.ContainerService/fleets/updateStrategies:auto_managed_patterns:^strategy\\.stages\\.\\d+\\.afterStageWaitInSeconds$": {
+      "matchCount": 5,
+      "firstMatched": "2026-05-18T23:06:29.633543+00:00",
+      "lastMatched": "2026-05-18T23:19:10.964598+00:00"
+    },
+    "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^azureMonitorProfile\\.metrics\\.controlPlane$": {
+      "matchCount": 5,
+      "firstMatched": "2026-05-18T23:06:29.633543+00:00",
+      "lastMatched": "2026-05-18T23:19:10.964598+00:00"
+    },
+    "Microsoft.Network/privateDnsZones/virtualNetworkLinks:auto_managed_patterns:^resolutionPolicy$": {
+      "matchCount": 5,
+      "firstMatched": "2026-05-18T23:06:29.633543+00:00",
+      "lastMatched": "2026-05-18T23:19:10.964598+00:00"
+    },
+    "Microsoft.Authorization/roleAssignments:auto_managed_patterns:^principalType$": {
+      "matchCount": 4,
+      "firstMatched": "2026-05-18T23:11:17.563406+00:00",
+      "lastMatched": "2026-05-18T23:19:10.964598+00:00"
+    },
+    "Microsoft.Authorization/roleAssignments:auto_managed_patterns:^principalId$": {
+      "matchCount": 4,
+      "firstMatched": "2026-05-18T23:11:17.563406+00:00",
+      "lastMatched": "2026-05-18T23:19:10.964598+00:00"
+    },
+    "Microsoft.Insights/scheduledQueryRules:auto_managed_patterns:^windowSize$": {
+      "matchCount": 3,
+      "firstMatched": "2026-05-18T23:13:14.888125+00:00",
+      "lastMatched": "2026-05-18T23:19:10.964598+00:00"
+    },
+    "Microsoft.ContainerService/managedClusters/providers/diagnosticSettings:auto_managed_patterns:^metrics$": {
+      "matchCount": 2,
+      "firstMatched": "2026-05-18T23:15:22.306674+00:00",
+      "lastMatched": "2026-05-18T23:19:10.964598+00:00"
+    },
+    "Microsoft.ContainerService/managedClusters/providers/diagnosticSettings:auto_managed_patterns:^logs\\.\\d+$": {
+      "matchCount": 2,
+      "firstMatched": "2026-05-18T23:15:22.306674+00:00",
+      "lastMatched": "2026-05-18T23:19:10.964598+00:00"
+    },
+    "Microsoft.ContainerService/managedClusters/providers/diagnosticSettings:auto_managed_patterns:^logs\\.\\d+\\.retentionPolicy\\.days$": {
+      "matchCount": 2,
+      "firstMatched": "2026-05-18T23:15:22.306674+00:00",
+      "lastMatched": "2026-05-18T23:19:10.964598+00:00"
+    },
+    "Microsoft.ContainerService/managedClusters/providers/dataCollectionRuleAssociations:auto_managed_patterns:^dataCollectionRuleId$": {
+      "matchCount": 2,
+      "firstMatched": "2026-05-18T23:15:22.306674+00:00",
+      "lastMatched": "2026-05-18T23:19:10.964598+00:00"
     }
   },
-  "lastRun": "2026-05-10T11:33:58.929649+00:00"
+  "lastRun": "2026-05-18T23:19:10.964598+00:00"
 }

--- a/.github/skills/bicep-what-if-analysis/scripts/what_if_analyzer.py
+++ b/.github/skills/bicep-what-if-analysis/scripts/what_if_analyzer.py
@@ -17,6 +17,7 @@ import json
 import logging
 import os
 import re
+import shutil
 import subprocess
 import sys
 from datetime import datetime, timezone
@@ -1007,7 +1008,7 @@ def get_azd_env_values() -> dict[str, str]:
     """azd env get-values から環境変数を取得する。"""
     try:
         result = subprocess.run(
-            ["azd", "env", "get-values"],
+            [shutil.which("azd") or "azd", "env", "get-values"],
             capture_output=True,
             text=True,
             check=True,
@@ -1280,6 +1281,10 @@ def run_what_if(
         "json",
         "--no-pretty-print",
     ]
+    # Windows: resolve az -> az.cmd so subprocess can find it without shell=True
+    resolved = shutil.which(cmd[0])
+    if resolved:
+        cmd[0] = resolved
 
     if subscription:
         cmd.extend(["--subscription", subscription])

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
       - name: Validate K8s manifests
         run: |
           kubeconform -strict -summary \
-            -kubernetes-version 1.33.0 \
+            -kubernetes-version 1.34.0 \
             -skip VerticalPodAutoscaler,CiliumNetworkPolicy,Kustomization,Gateway,HTTPRoute,Instrumentation \
             k8s/apps/chaos-app/*.yaml
   workflows-lint:

--- a/azure.yaml
+++ b/azure.yaml
@@ -31,6 +31,7 @@ services:
     project: src
     language: python
     host: aks
+    resourceName: ${AZURE_AKS_CLUSTER_NAME}
     k8s:
       namespace: chaos-lab
       kustomize:
@@ -48,6 +49,7 @@ services:
   observability:
     project: .
     host: aks
+    resourceName: ${AZURE_AKS_CLUSTER_NAME}
     hooks:
       postdeploy:
         windows:
@@ -63,6 +65,7 @@ services:
   chaos-mesh:
     project: .
     host: aks
+    resourceName: ${AZURE_AKS_CLUSTER_NAME}
     k8s:
       namespace: chaos-testing
       helm:

--- a/docs/workarounds.md
+++ b/docs/workarounds.md
@@ -153,6 +153,21 @@ ID は履歴追跡用に固定する。削除済み ID は再利用しない。
 - **確認方法**: fresh `azd up` 直後に `kubectl -n chaos-lab exec <pod> -- printenv | grep '^OTEL_'` を確認し、`OTelLogs` / `OTelSpans` が到達するか確認する。未注入なら `kubectl rollout restart deployment/chaos-app -n chaos-lab` 後に再確認する。
 - **最終確認**: 2026-05-17、fresh `azd up` 直後の `chaos-app` Pod で `OTEL_*` env が空。削除不可。
 
+### D-8. azd preflight が `Microsoft.Chaos/targets` に reserved-word warning を誤検知
+
+- **概要**: `azd up` / `azd provision` 実行時に以下の warning が出る。`Microsoft.Chaos/targets` の名前 `microsoft-azurekubernetesservicechaosmesh` は Azure Chaos Studio 仕様で固定であり、変更不可。
+  ```
+  (!) Warning: Resource "microsoft-azurekubernetesservicechaosmesh" (Microsoft.Chaos/targets) contains the reserved word "MICROSOFT"
+    Azure does not allow reserved words in resource names. The deployment will fail.
+  ```
+- **理由**: azd の preflight (`cli/azd/pkg/infra/provisioning/bicep/bicep_provider.go` の `azureReservedResourceNameContainsMatches = ["MICROSOFT", "WINDOWS"]`) が、`azureReservedResourceNameExemptTypes` に未登録の `Microsoft.Chaos/targets` を弾く。target type 名は Chaos Studio capability binding (`urn:csci:microsoft:azureKubernetesServiceChaosMesh:*`) と一対一で固定されており、サービス仕様上の固有名。ARM 側で reserved-word ルールは適用されないため、warning に反してデプロイは成功する（false positive）。
+- **実害評価**: なし。`azd` 実行ログにノイズが出るのみ。
+- **場所**: `infra/modules/chaos/experiments.bicep` の `chaosTarget` リソース（コメントで根拠を明記済み）。
+- **解消条件**: upstream で `Microsoft.Chaos/targets` が exempt list に追加される。
+- **追跡**: [Azure/azure-dev#8239](https://github.com/Azure/azure-dev/issues/8239)
+- **確認方法**: 上記 upstream issue が close されたバージョンの `azd` で `azd up` を実行し、warning が出ないことを確認する。
+- **最終確認**: 2026-05-19、`azd up` で warning が出るがデプロイは成功。Chaos experiment も正常動作。
+
 ### D-7. ama-metrics `mdsd.err` で `AMACoreAgent: Connection refused` が多発（実害なし・ログノイズのみ）
 
 - **概要**: `ama-metrics` Deployment の replica pod (`prometheus-collector` container) で `mdsd.err` に `[CreateSocket] Failed to connect port 12564 ... to AMACoreAgent: Connection refused` と `[OtlpTokenFetcher] AMACoreAgent tenant not started, trying to start it. DCR Contents: ...dcr-<otlp>...` が約 60 秒周期で継続出力される。

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -25,7 +25,7 @@ param peSubnetPrefix string = '10.10.2.0/24'
 param aksApiSubnetPrefix string = '10.10.3.0/28'
 
 @description('Kubernetes version for AKS (x.y or x.y.z).')
-param kubernetesVersion string = '1.33'
+param kubernetesVersion string = '1.34'
 
 @description('AKS SKU mode. Only "Base" is supported in this repository (see ADR-010: AKS Automatic is incompatible with chaos-mesh due to AKS Automatic Deployment Safeguards).')
 @allowed([

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -27,7 +27,7 @@
       "value": "10.10.3.0/28"
     },
     "kubernetesVersion": {
-      "value": "1.33"
+      "value": "1.34"
     },
     "aksSkuName": {
       "value": "${AKS_SKU_NAME:Base}"

--- a/infra/modules/aks.bicep
+++ b/infra/modules/aks.bicep
@@ -5,7 +5,7 @@ param aksName string
 @description('Tags object')
 param tags object = {}
 @description('Kubernetes version (x.y or x.y.z).')
-param kubernetesVersion string = '1.33'
+param kubernetesVersion string = '1.34'
 @description('Node resource group name for AKS managed resources')
 param nodeResourceGroupName string
 @description('Node VM size')

--- a/infra/modules/azmonitor/core.bicep
+++ b/infra/modules/azmonitor/core.bicep
@@ -45,7 +45,7 @@ resource applicationInsights 'Microsoft.Insights/components@2020-02-02' = {
     WorkspaceResourceId: logAnalyticsWorkspace.id
     IngestionMode: 'LogAnalytics'
     #disable-next-line BCP037
-    AzureMonitorWorkspaceIngestionMode: 'OptedIn'
+    AzureMonitorWorkspaceIngestionMode: 'Enabled'
     #disable-next-line BCP037
     AzureMonitorWorkspaceResourceId: appAzureMonitorWorkspace.id
   }

--- a/infra/modules/chaos/experiments.bicep
+++ b/infra/modules/chaos/experiments.bicep
@@ -58,8 +58,13 @@ resource aksCluster 'Microsoft.ContainerService/managedClusters@2026-03-02-previ
   scope: resourceGroup()
 }
 
-// Azure Chaos Studio documents this AKS Chaos Mesh target type name. ARM validation
-// may warn about the reserved word, but changing the target name breaks capability binding.
+// Azure Chaos Studio mandates this target type name for AKS Chaos Mesh.
+// `azd` preflight emits a false-positive "contains the reserved word MICROSOFT"
+// warning because Microsoft.Chaos/targets is not in its exempt list. The name is
+// bound to capability URNs (urn:csci:microsoft:azureKubernetesServiceChaosMesh:*)
+// and cannot be changed. ARM does not enforce the reserved-word rule here, so
+// deployment succeeds despite the warning. Tracked in docs/workarounds.md D-8 /
+// Azure/azure-dev#8239.
 resource chaosTarget 'Microsoft.Chaos/targets@2025-01-01' = {
   name: 'microsoft-azurekubernetesservicechaosmesh'
   scope: aksCluster

--- a/k8s/apps/chaos-app/kustomization.yaml
+++ b/k8s/apps/chaos-app/kustomization.yaml
@@ -138,4 +138,4 @@ patches:
 images:
 - name: placeholder
   newName: acr5dua5pkulsr3e.azurecr.io/aks-chaos-lab/api-eval
-  newTag: azd-deploy-1776165518
+  newTag: azd-deploy-1779149477


### PR DESCRIPTION
## 概要

AKS の Kubernetes バージョンを 1.33 → 1.34 にアップグレードするとともに、`azd up` 実行時に観測された誤検知ノイズ／drift をまとめて解消する。

## 変更内容

### AKS 1.34 アップグレード
- `infra/main.bicep` / `infra/main.parameters.json` / `infra/modules/aks.bicep` の `kubernetesVersion` を `1.34` に更新
- `.github/workflows/ci.yml` の kubeconform `-kubernetes-version` を `1.34.0` に追従

### Azure Monitor drift 解消
- `infra/modules/azmonitor/core.bicep`: Application Insights の `AzureMonitorWorkspaceIngestionMode` を `OptedIn` → `Enabled` に変更（Azure 側で `Enabled` に正規化されるため what-if で毎回 drift として検出されていた）

### azd preflight false positive の文書化
- `infra/modules/chaos/experiments.bicep`: `Microsoft.Chaos/targets` の名前 `microsoft-azurekubernetesservicechaosmesh` が Azure Chaos Studio 仕様で固定であり、azd の reserved-word チェックが誤検知することをコメントで明記
- `docs/workarounds.md` に **D-8** を追加（upstream: [Azure/azure-dev#8239](https://github.com/Azure/azure-dev/issues/8239)）

### azure.yaml の AKS ターゲット明示化
- `api` / `observability` / `chaos-mesh` 各サービスに `resourceName: ${AZURE_AKS_CLUSTER_NAME}` を追加し、複数 AKS が存在する場合でも azd が正しいクラスタを選択するようにする

### bicep-what-if-analysis skill 改善
- `what_if_analyzer.py`: Windows で `az` / `azd` を `shutil.which` 経由で解決し、subprocess が `.cmd` を見つけられるようにする
- `noise_patterns.json` / `pattern_stats.json` を最新化

### その他
- `k8s/apps/chaos-app/kustomization.yaml`: `azd deploy` 生成のイメージタグ更新

## 品質ゲート

- [x] `az bicep build --file infra/main.bicep` エラー 0
- [x] `azd up` で実環境（eval）にデプロイ成功
- [x] Chaos experiment 正常動作確認

## 関連

- `docs/workarounds.md` D-8 / [Azure/azure-dev#8239](https://github.com/Azure/azure-dev/issues/8239)
- メモリ: Application Insights `AzureMonitorWorkspaceIngestionMode` の drift 対策
