### PR TITLE
Improve Windows Locust load test workflow

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -51,6 +51,12 @@ docs/features/    # Feature Document（作業途中の状態保存）
 - **Python**: ty エラー 0 件、ruff 警告 0 件、pytest 全テスト合格
 - **Bicep**: `az bicep build` エラー 0 件
 
+## Windows / cross-shell 注意
+
+- Windows で Locust 負荷テストを実行する場合は、`uv run locust ...` を直接使わず `uv run scripts/tasks.py load-*` を使う。wrapper が child process に `PYTHONUTF8=1` を設定し、cp932 などの既定 encoding による TOML 読み取り失敗を避ける。
+- Locust CSV 出力は `LOCUST_CSV_PREFIX` と、必要な場合のみ `LOCUST_CSV_FULL_HISTORY=true` で指定する。任意引数を広く通す `LOCUST_EXTRA_ARGS` のような仕組みは追加しない。
+- WSL / bash helper に Windows path を渡す場合は、`C:\...` ではなく `/mnt/c/...` 形式へ変換する。PowerShell / Windows native shell では `C:\...` 形式を使う。
+
 ## 知識ソース
 
 コード生成・技術選定・構成変更の際は、以下を確認すること:

--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -20,6 +20,8 @@ KUBECONFORM_IMAGE = "ghcr.io/yannh/kubeconform:v0.7.0"
 K8S_VERSION = "1.33.0"
 KUBECONFORM_SKIP = "VerticalPodAutoscaler,CiliumNetworkPolicy,Kustomization,Gateway,HTTPRoute,Instrumentation"
 SCRIPT_RUFF_IGNORES = "S104,S310,S603,T201"
+TRUE_ENV_VALUES = {"1", "true", "yes", "on"}
+FALSE_ENV_VALUES = {"0", "false", "no", "off"}
 
 
 def print_step(message: str) -> None:
@@ -58,6 +60,25 @@ def pythonpath_env() -> dict[str, str]:
     existing = env.get("PYTHONPATH")
     env["PYTHONPATH"] = f".{os.pathsep}{existing}" if existing else "."
     return env
+
+
+def env_flag(name: str) -> bool:
+    value = os.environ.get(name)
+    if value is None or value == "":
+        return False
+
+    normalized = value.strip().lower()
+    if normalized in TRUE_ENV_VALUES:
+        return True
+    if normalized in FALSE_ENV_VALUES:
+        return False
+
+    print(
+        f"error: {name} must be one of: "
+        f"{', '.join(sorted(TRUE_ENV_VALUES | FALSE_ENV_VALUES))}",
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
 
 
 def run(
@@ -537,30 +558,46 @@ def run_load_profile(profile: str) -> None:
     spawn_rate = os.environ.get("SPAWN_RATE", default_spawn_rate)
     duration = os.environ.get("DURATION", default_duration)
     base_url = resolve_base_url()
+    csv_prefix = os.environ.get("LOCUST_CSV_PREFIX")
+    if csv_prefix is not None and csv_prefix.strip() == "":
+        csv_prefix = None
+    csv_full_history = env_flag("LOCUST_CSV_FULL_HISTORY")
+    if csv_full_history and not csv_prefix:
+        print(
+            "error: LOCUST_CSV_FULL_HISTORY requires LOCUST_CSV_PREFIX",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
 
     env = child_env({"TEST_BASE_PATH": base_url})
+    locust_args = [
+        "locust",
+        "-f",
+        "tests/load/locustfile.py",
+        "--headless",
+        "-u",
+        users,
+        "-r",
+        spawn_rate,
+        "--run-time",
+        duration,
+        "--host",
+        base_url,
+    ]
+    if csv_prefix:
+        locust_args.extend(["--csv", csv_prefix])
+        if csv_full_history:
+            locust_args.append("--csv-full-history")
+
+    csv_detail = (
+        f" csv={csv_prefix} csv_full_history={csv_full_history}" if csv_prefix else ""
+    )
     print(
         f"[load] profile={profile} users={users} spawn_rate={spawn_rate}/s "
-        f"duration={duration}s host={base_url}",
+        f"duration={duration}s host={base_url}{csv_detail}",
         file=sys.stderr,
     )
-    run_uv_src_dev(
-        [
-            "locust",
-            "-f",
-            "tests/load/locustfile.py",
-            "--headless",
-            "-u",
-            users,
-            "-r",
-            spawn_rate,
-            "--run-time",
-            duration,
-            "--host",
-            base_url,
-        ],
-        env=env,
-    )
+    run_uv_src_dev(locust_args, env=env)
 
 
 def target_load_smoke() -> None:

--- a/src/tests/load/README.md
+++ b/src/tests/load/README.md
@@ -26,6 +26,11 @@ uv run scripts/tasks.py load-stress
 uv run scripts/tasks.py load-spike
 ```
 
+Windows では、`uv run locust ...` を直接実行すると端末の既定 encoding
+（cp932 など）で TOML 読み取りに失敗することがあります。`scripts/tasks.py`
+は child process に `PYTHONUTF8=1` を設定するため、Windows では
+`uv run scripts/tasks.py load-*` 経由で実行してください。
+
 ### 手動でBASE_URL指定
 ```bash
 export BASE_URL=https://myapp.example.com
@@ -52,6 +57,36 @@ export SPAWN_RATE=10
 export DURATION=300
 uv run scripts/tasks.py load-baseline
 ```
+
+### CSV 出力
+
+`LOCUST_CSV_PREFIX` を指定すると Locust の `--csv <prefix>` を有効化できます。
+`LOCUST_CSV_FULL_HISTORY=true` を併用すると `--csv-full-history` も付与されます。
+`LOCUST_CSV_FULL_HISTORY` は `1` / `true` / `yes` / `on` で有効化し、
+`0` / `false` / `no` / `off` で無効化できます。
+
+PowerShell:
+
+```powershell
+New-Item -ItemType Directory -Force tmp\load | Out-Null
+$env:LOCUST_CSV_PREFIX = "..\tmp\load\baseline"
+$env:LOCUST_CSV_FULL_HISTORY = "true"
+uv run scripts/tasks.py load-baseline
+Remove-Item Env:LOCUST_CSV_PREFIX
+Remove-Item Env:LOCUST_CSV_FULL_HISTORY
+```
+
+Bash:
+
+```bash
+mkdir -p tmp/load
+LOCUST_CSV_PREFIX=../tmp/load/baseline \
+LOCUST_CSV_FULL_HISTORY=true \
+uv run scripts/tasks.py load-baseline
+```
+
+`scripts/tasks.py` は Locust を `src/` を current directory として起動するため、
+相対パスの prefix は `src/` からの相対パスとして解釈されます。
 
 ## 負荷プロファイル
 


### PR DESCRIPTION
Windows で負荷試験を実行する際に、Locust を直接起動すると端末の既定 encoding で `src/pyproject.toml` の読み取りに失敗することがありました。この PR は、既存の `scripts/tasks.py` wrapper 経由で CSV 出力まで完結できるようにして、Windows でも同じタスクで検証できる状態にします。

## 変更内容

- `run_load_profile()` で `LOCUST_CSV_PREFIX` を読み、指定時に Locust の `--csv <prefix>` を付与
- `LOCUST_CSV_FULL_HISTORY` を明示的な boolean env として扱い、必要な場合だけ `--csv-full-history` を付与
- `LOCUST_EXTRA_ARGS` のような任意引数パスは追加せず、wrapper の入力を予測可能な env に限定
- `.github/copilot-instructions.md` に Windows / cross-shell の作業時注意を追加
- `src/tests/load/README.md` に wrapper 利用と CSV 出力例を追加

## 検証

- `uv --no-progress run scripts/tasks.py qa-scripts`
- `uv --no-progress run scripts/tasks.py qa-app`
- CSV env の Locust 引数変換チェック
- `az bicep build --file infra\main.bicep`