### PR TITLE
feat(hooks): surface bicep build warnings via postToolUse feedback

### DIFF
--- a/.github/hooks/scripts/post-edit-quality-feedback.py
+++ b/.github/hooks/scripts/post-edit-quality-feedback.py
@@ -24,6 +24,14 @@ from shutil import which
 COMMAND_TIMEOUT_SEC = 45
 MAX_OUTPUT_CHARS = 1600
 MAX_CONTEXT_CHARS = 4000
+MAX_BICEP_WARNINGS = 10
+
+# Substrings that mark `az bicep build` stderr lines as tool-side notices
+# (e.g. CLI upgrade hints) rather than code diagnostics.
+IGNORE_BICEP_NOTICE_PATTERNS: tuple[str, ...] = (
+    "A new Bicep release is available",
+    "Upgrade now by running",
+)
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
@@ -249,6 +257,45 @@ def _normalize_eol(content: bytes, eol: bytes) -> bytes:
     return unified.replace(b"\n", b"\r\n")
 
 
+def _is_bicep_notice(line: str) -> bool:
+    return any(pattern in line for pattern in IGNORE_BICEP_NOTICE_PATTERNS)
+
+
+def extract_bicep_warnings(result: CommandResult) -> list[str]:
+    """Pick `Warning` diagnostic lines from a successful bicep build run.
+
+    Tool-side notices (CLI upgrade hints, etc.) are filtered out so only
+    actionable code diagnostics surface to the agent.
+    """
+
+    warnings: list[str] = []
+    for raw_line in result.stderr.splitlines():
+        line = raw_line.strip()
+        if not line or "Warning" not in line:
+            continue
+        if _is_bicep_notice(line):
+            continue
+        warnings.append(line)
+
+    if len(warnings) <= MAX_BICEP_WARNINGS:
+        return warnings
+
+    truncated = warnings[:MAX_BICEP_WARNINGS]
+    remaining = len(warnings) - MAX_BICEP_WARNINGS
+    truncated.append(f"(+{remaining} more)")
+    return truncated
+
+
+def warnings_message(path: Path, warnings: list[str]) -> str:
+    joined = "\n".join(warnings)
+    summary = (
+        joined
+        if len(joined) <= MAX_OUTPUT_CHARS
+        else f"{joined[:MAX_OUTPUT_CHARS].rstrip()}..."
+    )
+    return f"Bicep build warnings for `{path}`:\n{summary}"
+
+
 def process_bicep(path: Path) -> list[str]:
     before = path.read_bytes()
     original_eol = _detect_eol(before)
@@ -269,6 +316,10 @@ def process_bicep(path: Path) -> list[str]:
         )
         if build_result.failed:
             messages.append(failure_message(path, build_result))
+        else:
+            warnings = extract_bicep_warnings(build_result)
+            if warnings:
+                messages.append(warnings_message(path, warnings))
 
     if path.exists() and path.read_bytes() != before:
         messages.append(file_changed_message(path))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,11 @@ ignore = [
   "S603", # subprocess invocations
   "T201", # print is the intended UX for CLI scripts
 ]
+# Hook scripts: same operational profile as scripts/.
+".github/hooks/scripts/**/*.py" = [
+  "S603", # subprocess invocations
+  "T201",
+]
 
 [tool.ty.environment]
 python-version = "3.14"


### PR DESCRIPTION
## Summary

Extend the postToolUse quality hook so `az bicep build` warnings (BCP035, linter rules, etc.) reach the agent instead of being silently dropped.

Previously the hook only reported output when `az bicep build` exited with a non-zero status. Bicep emits `Warning`-level diagnostics with exit 0, so warnings on edited files never surfaced.

## Changes

- `.github/hooks/scripts/post-edit-quality-feedback.py`
  - Add `IGNORE_BICEP_NOTICE_PATTERNS` to filter tool-side notices (e.g. `A new Bicep release is available`).
  - Add `extract_bicep_warnings` / `warnings_message` helpers (cap at 10 entries with `(+N more)` suffix).
  - In `process_bicep` invoke the warning extractor only when the build succeeds, avoiding double-reporting on failures.
- `pyproject.toml`
  - Add a `per-file-ignores` entry for `.github/hooks/scripts/**/*.py` (`S603`, `T201`) mirroring the existing `scripts/**/*.py` profile.

## Verification

Manual hook run with three temporary Bicep files:

| Case | Expected | Result |
|---|---|---|
| BCP035 only (missing required props) | Warning surfaced via `additionalContext`; CLI upgrade notice filtered | OK |
| Syntax error + warnings | Existing failure path with full output summary; no duplicate warning message | OK |
| Clean Bicep | No feedback emitted | OK |

`uv run ruff check .github/hooks/scripts/ pyproject.toml` passes after the per-file-ignore addition.

## Notes

The unrelated 17 ruff errors under `.github/skills/bicep-what-if-analysis/scripts/` are tracked in a separate session and out of scope here.