### PR TITLE
chore(skills): fix ruff errors in bicep-what-if-analysis

### DIFF
--- a/.github/skills/bicep-what-if-analysis/scripts/tests/test_what_if_analyzer.py
+++ b/.github/skills/bicep-what-if-analysis/scripts/tests/test_what_if_analyzer.py
@@ -108,7 +108,11 @@ class TestContainsArmReference(unittest.TestCase):
 
     def test_resourceid_function(self) -> None:
         """resourceId() 関数を検出"""
-        self.assertTrue(contains_arm_reference("[resourceId('Microsoft.Network/virtualNetworks', 'vnet')]"))
+        self.assertTrue(
+            contains_arm_reference(
+                "[resourceId('Microsoft.Network/virtualNetworks', 'vnet')]"
+            )
+        )
 
     def test_plain_string(self) -> None:
         """通常の文字列は検出しない"""
@@ -306,7 +310,10 @@ class TestDisplayConfigLoader(unittest.TestCase):
         """表示名を読み込める"""
         loader = DisplayConfigLoader()
         names = loader.get_display_names()
-        self.assertEqual(names.get("Microsoft.ContainerService/managedClusters"), "AKS Managed Cluster")
+        self.assertEqual(
+            names.get("Microsoft.ContainerService/managedClusters"),
+            "AKS Managed Cluster",
+        )
 
     def test_load_filtered_types(self) -> None:
         """フィルタリング対象を読み込める"""
@@ -622,7 +629,10 @@ class TestIsCreateFalsePositive(unittest.TestCase):
             "resourceName": "vnet-new",
             "resourceId": "/subscriptions/sub/resourceGroups/rg/providers/Microsoft.Network/virtualNetworks/vnet-new",
             "beforeState": None,
-            "afterState": {"type": "Microsoft.Network/virtualNetworks", "name": "vnet-new"},
+            "afterState": {
+                "type": "Microsoft.Network/virtualNetworks",
+                "name": "vnet-new",
+            },
             "propertyChanges": [],
         }
         self.assertFalse(is_create_false_positive(change))
@@ -753,6 +763,7 @@ class TestFormatAzdStyleOutputFalsePositive(unittest.TestCase):
         self.assertNotIn("exp-aks-pod-failure", result)
         self.assertIn("aks-test", result)
         self.assertIn("1 件の Create を非表示", result)
+
     def test_no_summary_when_no_false_positives(self) -> None:
         """false positive がない場合はサマリー行なし"""
         output_data = {
@@ -781,12 +792,11 @@ class TestParseAzureYamlLayers(unittest.TestCase):
     """parse_azure_yaml_layers のテスト"""
 
     def _write_yaml(self, content: str) -> str:
-        f = tempfile.NamedTemporaryFile(
+        with tempfile.NamedTemporaryFile(
             mode="w", suffix=".yaml", delete=False, encoding="utf-8"
-        )
-        f.write(content)
-        f.close()
-        return f.name
+        ) as f:
+            f.write(content)
+            return f.name
 
     def test_repo_format(self) -> None:
         """本リポと同じ multi-layer 形式を解析できる"""
@@ -824,10 +834,7 @@ class TestParseAzureYamlLayers(unittest.TestCase):
     def test_quoted_values_stripped(self) -> None:
         """quote を剥がす"""
         path = self._write_yaml(
-            "infra:\n"
-            "  layers:\n"
-            '    - name: "base"\n'
-            "      path: './infra'\n"
+            "infra:\n  layers:\n    - name: \"base\"\n      path: './infra'\n"
         )
         self.assertEqual(
             parse_azure_yaml_layers(path), [{"name": "base", "path": "./infra"}]
@@ -848,10 +855,7 @@ class TestParseAzureYamlLayers(unittest.TestCase):
     def test_path_first_then_name(self) -> None:
         """- path: で項目が始まり次に name: の形式も解析できる"""
         path = self._write_yaml(
-            "infra:\n"
-            "  layers:\n"
-            "    - path: ./infra/sli\n"
-            "      name: sli\n"
+            "infra:\n  layers:\n    - path: ./infra/sli\n      name: sli\n"
         )
         self.assertEqual(
             parse_azure_yaml_layers(path), [{"name": "sli", "path": "./infra/sli"}]
@@ -919,12 +923,11 @@ class TestGetBicepParamNames(unittest.TestCase):
     """get_bicep_param_names のテスト"""
 
     def _write_bicep(self, content: str) -> str:
-        f = tempfile.NamedTemporaryFile(
+        with tempfile.NamedTemporaryFile(
             mode="w", suffix=".bicep", delete=False, encoding="utf-8"
-        )
-        f.write(content)
-        f.close()
-        return f.name
+        ) as f:
+            f.write(content)
+            return f.name
 
     def test_extracts_params(self) -> None:
         """param 宣言を抽出する"""
@@ -942,10 +945,7 @@ class TestGetBicepParamNames(unittest.TestCase):
 
     def test_skips_commented_param(self) -> None:
         """コメント行内の 'param' は拾わない"""
-        path = self._write_bicep(
-            "// param disabled string\n"
-            "param environment string\n"
-        )
+        path = self._write_bicep("// param disabled string\nparam environment string\n")
         self.assertEqual(get_bicep_param_names(path), {"environment"})
 
     def test_missing_template(self) -> None:
@@ -957,12 +957,11 @@ class TestResolveParametersFilePlaceholders(unittest.TestCase):
     """resolve_parameters_file_placeholders のテスト"""
 
     def _write_params(self, data: dict) -> str:
-        f = tempfile.NamedTemporaryFile(
+        with tempfile.NamedTemporaryFile(
             mode="w", suffix=".json", delete=False, encoding="utf-8"
-        )
-        json.dump(data, f)
-        f.close()
-        return f.name
+        ) as f:
+            json.dump(data, f)
+            return f.name
 
     def test_resolves_env_var(self) -> None:
         """${VAR} を env から解決する"""
@@ -974,9 +973,7 @@ class TestResolveParametersFilePlaceholders(unittest.TestCase):
                 }
             }
         )
-        result = resolve_parameters_file_placeholders(
-            path, {"AZURE_ENV_NAME": "eval"}
-        )
+        result = resolve_parameters_file_placeholders(path, {"AZURE_ENV_NAME": "eval"})
         self.assertEqual(result, {"environment": "eval"})
 
     def test_uses_default_when_env_missing(self) -> None:
@@ -989,9 +986,7 @@ class TestResolveParametersFilePlaceholders(unittest.TestCase):
 
     def test_skips_when_no_env_no_default(self) -> None:
         """env も default もなければ含めない (file の literal がそのまま渡る)"""
-        path = self._write_params(
-            {"parameters": {"x": {"value": "${MISSING_VAR}"}}}
-        )
+        path = self._write_params({"parameters": {"x": {"value": "${MISSING_VAR}"}}})
         self.assertEqual(resolve_parameters_file_placeholders(path, {}), {})
 
     def test_ignores_non_string_values(self) -> None:
@@ -1007,9 +1002,7 @@ class TestResolveParametersFilePlaceholders(unittest.TestCase):
                 }
             }
         )
-        result = resolve_parameters_file_placeholders(
-            path, {"AZURE_ENV_NAME": "eval"}
-        )
+        result = resolve_parameters_file_placeholders(path, {"AZURE_ENV_NAME": "eval"})
         self.assertEqual(result, {"name": "eval"})
 
     def test_ignores_partial_placeholder(self) -> None:
@@ -1018,9 +1011,7 @@ class TestResolveParametersFilePlaceholders(unittest.TestCase):
             {"parameters": {"x": {"value": "prefix-${AZURE_ENV_NAME}-suffix"}}}
         )
         self.assertEqual(
-            resolve_parameters_file_placeholders(
-                path, {"AZURE_ENV_NAME": "eval"}
-            ),
+            resolve_parameters_file_placeholders(path, {"AZURE_ENV_NAME": "eval"}),
             {},
         )
 
@@ -1033,9 +1024,7 @@ class TestResolveParametersFilePlaceholders(unittest.TestCase):
     def test_default_with_empty_string(self) -> None:
         """${VAR:} (空 default) は空文字列を返す"""
         path = self._write_params({"parameters": {"x": {"value": "${VAR:}"}}})
-        self.assertEqual(
-            resolve_parameters_file_placeholders(path, {}), {"x": ""}
-        )
+        self.assertEqual(resolve_parameters_file_placeholders(path, {}), {"x": ""})
 
 
 class TestRunWhatIfCommandConstruction(unittest.TestCase):

--- a/.github/skills/bicep-what-if-analysis/scripts/what_if_analyzer.py
+++ b/.github/skills/bicep-what-if-analysis/scripts/what_if_analyzer.py
@@ -20,7 +20,7 @@ import re
 import shutil
 import subprocess
 import sys
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -252,7 +252,7 @@ class NoisePatternLoader:
         try:
             with open(self._stats_file, encoding="utf-8") as f:
                 self._stats = json.load(f)
-        except (FileNotFoundError, json.JSONDecodeError):
+        except FileNotFoundError, json.JSONDecodeError:
             self._stats = {"patterns": {}, "lastRun": None}
 
         return self._stats
@@ -276,22 +276,18 @@ class NoisePatternLoader:
                     valid_keys.add(f"{category}:{item['pattern']}")
 
         # リソースタイプ別パターン
-        for resource_type, resource_patterns in (
-            data.get("resource_types", {}).items()
-        ):
+        for resource_type, resource_patterns in data.get("resource_types", {}).items():
             for category in pattern_categories:
                 for item in resource_patterns.get(category, []):
                     if isinstance(item, dict) and "pattern" in item:
-                        valid_keys.add(
-                            f"{resource_type}:{category}:{item['pattern']}"
-                        )
+                        valid_keys.add(f"{resource_type}:{category}:{item['pattern']}")
 
         return valid_keys
 
     def save_stats(self) -> None:
         """統計ファイルを保存する。"""
         stats = self._load_stats()
-        now = datetime.now(timezone.utc).isoformat()
+        now = datetime.now(UTC).isoformat()
 
         stats["lastRun"] = now
 
@@ -329,14 +325,16 @@ class NoisePatternLoader:
             未使用パターンのリスト
         """
         stats = self._load_stats()
-        now = datetime.now(timezone.utc)
+        now = datetime.now(UTC)
         threshold = now - __import__("datetime").timedelta(days=days)
         unused = []
 
         for key, info in stats.get("patterns", {}).items():
             last_matched_str = info.get("lastMatched")
             if last_matched_str:
-                last_matched = datetime.fromisoformat(last_matched_str.replace("Z", "+00:00"))
+                last_matched = datetime.fromisoformat(
+                    last_matched_str.replace("Z", "+00:00")
+                )
                 if last_matched < threshold:
                     # キー形式: "resource_type:category:pattern" または "category:pattern"
                     parts = key.split(":")
@@ -395,9 +393,10 @@ def match_known_default(
 
     path_end = check_path.split(".")[-1]
     for default_path, default_value, description in known_defaults:
-        if path_end == default_path or check_path.endswith(default_path):
-            if value == default_value:
-                return description
+        if (
+            path_end == default_path or check_path.endswith(default_path)
+        ) and value == default_value:
+            return description
     return None
 
 
@@ -494,7 +493,7 @@ class BicepFileCache:
         for bicep_file in bicep_path.rglob("*.bicep"):
             try:
                 self._cache[str(bicep_file)] = bicep_file.read_text(encoding="utf-8")
-            except (IOError, UnicodeDecodeError):
+            except OSError, UnicodeDecodeError:
                 continue
 
         return self._cache
@@ -676,7 +675,9 @@ def find_array_element_range(
     for i in range(start_search, len(lines)):
         line = lines[i]
         stripped = line.strip()
-        if stripped.startswith(f"{array_name}:") or stripped.startswith(f"{array_name} :"):
+        if stripped.startswith(f"{array_name}:") or stripped.startswith(
+            f"{array_name} :"
+        ):
             array_start_idx = i
             break
 
@@ -702,7 +703,7 @@ def find_array_element_range(
     for i in range(bracket_start_idx, len(lines)):
         line = lines[i]
 
-        for char_idx, char in enumerate(line):
+        for _char_idx, char in enumerate(line):
             if char == "[" and i == bracket_start_idx:
                 # 配列の開始
                 continue
@@ -916,12 +917,11 @@ def find_bicep_definition(
                         continue
 
                     # 配列インデックスがある場合、特定の要素内にあるか検証
-                    if array_indices:
-                        if not is_inside_array_element(
-                            lines, line_num, array_indices, resource_ranges
-                        ):
-                            matches.append(match_info)
-                            continue
+                    if array_indices and not is_inside_array_element(
+                        lines, line_num, array_indices, resource_ranges
+                    ):
+                        matches.append(match_info)
+                        continue
 
                     context_matches.append(match_info)
                 else:
@@ -1020,7 +1020,7 @@ def get_azd_env_values() -> dict[str, str]:
                 # クォートを除去
                 values[key] = value.strip("\"'")
         return values
-    except (subprocess.CalledProcessError, FileNotFoundError):
+    except subprocess.CalledProcessError, FileNotFoundError:
         return {}
 
 
@@ -1309,7 +1309,7 @@ def run_what_if(
         try:
             return json.loads(result.stdout)
         except json.JSONDecodeError:
-            raise RuntimeError(f"what-if failed: {result.stderr}")
+            raise RuntimeError(f"what-if failed: {result.stderr}") from None
 
     return json.loads(result.stdout)
 
@@ -1509,9 +1509,7 @@ def normalize_unsupported_extension_resource(
         return None
 
     extension_name = extension_type.split("/")[-1]
-    normalized_resource_id = (
-        f"{scope_id}/providers/{extension_type}/<dynamic>"
-    )
+    normalized_resource_id = f"{scope_id}/providers/{extension_type}/<dynamic>"
     resource_type = f"{scope_type}/providers/{extension_name}"
     resource_name = "<dynamic>"
     return normalized_resource_id, resource_type, resource_name
@@ -1531,7 +1529,10 @@ def is_known_acr_acrpull_unsupported(change: dict[str, Any]) -> bool:
         return False
 
     resource_type = str(change.get("resourceType", "")).lower()
-    if resource_type != "microsoft.containerregistry/registries/providers/roleassignments":
+    if (
+        resource_type
+        != "microsoft.containerregistry/registries/providers/roleassignments"
+    ):
         return False
 
     original_resource_id = str(change.get("originalResourceId", "")).lower()
@@ -1632,9 +1633,7 @@ def extract_resource_changes(
         }
 
         # Create false positive 判定
-        change_entry["likelyFalsePositive"] = is_create_false_positive(
-            change_entry
-        )
+        change_entry["likelyFalsePositive"] = is_create_false_positive(change_entry)
 
         changes.append(change_entry)
 
@@ -1719,7 +1718,7 @@ def build_output(
             "template": template,
             "location": location,
             "bicepDir": bicep_dir,
-            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "timestamp": datetime.now(UTC).isoformat(),
         },
         "summary": summary,
         "createFalsePositives": create_false_positives,
@@ -1772,7 +1771,10 @@ class DisplayConfigLoader:
                 self._data = json.load(f)
         except (FileNotFoundError, json.JSONDecodeError) as e:
             logger.warning("Failed to load display config file: %s", e)
-            self._data = {"resource_type_display_names": {}, "filtered_resource_types": []}
+            self._data = {
+                "resource_type_display_names": {},
+                "filtered_resource_types": [],
+            }
 
         return self._data
 
@@ -1941,9 +1943,7 @@ def format_azd_style_output(output_data: dict[str, Any]) -> str:
 
     # text 出力対象をフィルタリング
     display_candidates = [
-        c
-        for c in output_data["changes"]
-        if should_show_resource_in_text_output(c)
+        c for c in output_data["changes"] if should_show_resource_in_text_output(c)
     ]
 
     # Create false positive をフィルタ（件数は記録）

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,15 @@ ignore = [
   "S603", # subprocess invocations
   "T201",
 ]
+# Skill operational scripts: subprocess and CLI print are intentional
+".github/skills/bicep-what-if-analysis/scripts/**/*.py" = [
+  "S603", # subprocess invocations against trusted CLI args
+  "T201", # print is the intended UX for the analyzer CLI
+]
+# Skill tests: temp paths in fixtures are acceptable
+".github/skills/bicep-what-if-analysis/scripts/tests/**/*.py" = [
+  "S108", # /tmp/... strings are passed only to mocked subprocesses
+]
 
 [tool.ty.environment]
 python-version = "3.14"


### PR DESCRIPTION
## なぜ

`uv run ruff check .` が `.github/skills/bicep-what-if-analysis/scripts/` 配下で 17 件のエラーを出していました。リポジトリ全体の lint を緑に戻し、postToolUse hook の品質フィードバックがノイズなく機能するようにします。

## 変更内容

**`pyproject.toml` — 運用ノイズを per-file-ignore で抑止**
既存の `scripts/**/*.py` / `.github/hooks/scripts/**/*.py` のスタイルに合わせて 2 エントリ追加:
- skill 本体 (`...bicep-what-if-analysis/scripts/**/*.py`) → `S603` (信頼できる CLI 引数に対する subprocess), `T201` (アナライザ CLI の意図的な print)
- skill テスト (`.../tests/**/*.py`) → `S108` (mock subprocess に渡すだけの `/tmp/...` パス文字列)

**`what_if_analyzer.py` — コード自体を修正**
- `UP017` `UP024`: `timezone.utc` → `datetime.UTC`、`IOError` → `OSError` (ruff `--fix`)
- `SIM102` x2: ネストした `if` を `and` で統合
- `B007`: 未使用ループ変数を `_char_idx` にリネーム
- `B904`: `except json.JSONDecodeError` 内の `raise RuntimeError(...)` に `from None` を付与

**`tests/test_what_if_analyzer.py` — `SIM115` 修正**
- 3 つの `_write_*` ヘルパーで `tempfile.NamedTemporaryFile(..., delete=False)` を `with` 文に書き換え。`delete=False` のためファイルは残り、テスト挙動は変わらず

## 検証

- `uv run ruff check .` → All checks passed
- `uv run python -m pytest .github/skills/bicep-what-if-analysis/scripts/tests/test_what_if_analyzer.py` → 71 passed

## 備考

- 機能変更なし。ドキュメント更新は不要と判断
- `pyproject.toml` の改行コードは既存の CRLF を維持