### PR TITLE
chore(workflow): classify managed + auto-applied AKS updates as 🟡

### DIFF
--- a/.github/workflows/aks-updates-analyzer.md
+++ b/.github/workflows/aks-updates-analyzer.md
@@ -168,20 +168,33 @@ PYEOF
 
 ## Step 4: 影響度分析
 
-Step 1〜3 の情報を照合し、**Step 1 と Step 2 で取得した全アップデートを漏れなく**以下のカテゴリに分類してください:
+Step 1〜3 の情報を照合し、**Step 1 と Step 2 で取得した全アップデートを漏れなく**以下のカテゴリに分類してください。
 
-- 🔴 **要対応**: このリポジトリが**使用中**の機能・コンポーネントに影響する以下のいずれか:
-  - セキュリティ修正（CVE）を含むコンポーネント更新
+### 前提: 自動適用構成の解釈
+
+「🔴 / 🟡」を判定する前に、`infra/modules/aks.bicep` から以下の自動適用構成を必ず確認してください。CVE 修正・コンポーネント更新であっても、対象が「マネージドコンポーネント」かつ以下の自動適用構成が有効な場合は、ユーザー操作なしにロールアウトされるため **🔴 ではなく 🟡 に分類**します。
+
+- `autoUpgradeProfile.upgradeChannel` — Kubernetes コントロールプレーン / クラスタの自動更新
+- `autoUpgradeProfile.nodeOSUpgradeChannel` — ノード OS イメージの自動更新（CVE-mitigated node image を含む）
+- `Microsoft.ContainerService/managedClusters/maintenanceConfigurations` — `aksManagedAutoUpgradeSchedule` / `aksManagedNodeOSUpgradeSchedule` 等のスケジュール
+- AKS マネージド add-on / アドオン相当のマネージドコンポーネント全般（Cilium、Azure Policy add-on、CSI drivers、cloud-provider-azure、Container Insights、Managed Prometheus collector、Application Routing、Cost-analysis agent 等）
+
+なお「使用中」の判定は **bicep / k8s マニフェストでの明示的有効化が確認できるもの**のみ「使用中」とみなし、確認できない add-on / 機能は「未使用」として扱ってください（false-positive 防止）。
+
+### カテゴリ定義
+
+- 🔴 **要対応**: このリポジトリが**使用中**の機能・コンポーネントに影響し、かつ **ユーザー側のコード変更・運用操作が必要**なもの:
   - 非推奨化・廃止（Retirement / Deprecation）の影響を受けるもの
   - 破壊的変更（Breaking Changes）の影響を受けるもの
-- 🟡 **認識しておくべき**: 使用中の機能に関連するが即座のアクション不要:
+  - 自動適用構成の対象外であり、ユーザーが明示的にバージョン指定・パラメータ変更しない限り適用されない CVE 修正・更新
+- 🟡 **認識しておくべき**: 使用中の機能に関連するが即座のユーザー操作は不要:
   - Kubernetes パッチバージョン更新
   - 新リージョン対応
   - 将来バージョンでの動作変更予告
-  - マネージドコンポーネントの自動更新（CVE を含まないもの）
-- ⚪ **影響なし**: このリポジトリが**使用していない**機能に関するアップデート
+  - マネージドコンポーネントの自動更新（CVE 修正を含むものも、上記「自動適用構成」が有効な範囲では本カテゴリに分類し、推奨アクションは「自動適用後の動作確認」とする）
+- ⚪ **影響なし**: このリポジトリが**使用していない**機能に関するアップデート（明示的な有効化設定が無いものを含む）
 
-各項目には具体的な推奨アクションと、元ソースへのリンクを必ず含めてください。
+各項目には具体的な推奨アクションと、元ソースへのリンクを必ず含めてください。CVE-related 項目を 🟡 に分類した場合は、推奨アクションに「(自動適用) `nodeOSUpgradeChannel: <設定値>` / メンテナンスウィンドウ <曜日・時刻> により適用済み想定。`az aks ...` または `kubectl ...` で対象バージョンの到達を確認」のように、自動適用の根拠と確認コマンドを併記してください。
 
 ## Step 5: Issue を作成
 


### PR DESCRIPTION
## なぜ

週次 AKS アップデート分析ワークフロー (`aks-updates-analyzer`) が Issue #147 で false-positive を多発させた。Issue #147 の「🔴 要対応」3 件はいずれも実機検証で対応不要であることが判明:

- **CVE-2026-31431 (Ubuntu 24.04)**: `nodeOSUpgradeChannel: NodeImage` + 毎週水曜のメンテナンス窓で自動適用される構成だが、ワークフローはこれを解釈せず 🔴 に分類していた。実機ノードは緩和済みイメージ `202604.24.0` に既に到達。
- **Cilium v1.17.10**: マネージド更新だが 🔴 に分類。実機は K8s 1.34 ライン上で v1.18.9 に到達。
- **Azure Policy add-on 1.16.1 / Gatekeeper**: 本クラスタでは **add-on 自体が未導入** にもかかわらず「自動適用」と仮定し 🔴 に分類。

ワークフロー側のロジックを補正し、AKS マネージドかつ自動適用構成が有効なコンポーネント更新は、CVE 修正を含んでも「🟡 認識しておくべき (自動適用後の動作確認)」に格下げするルールを明文化する。

## アプローチ

`.github/workflows/aks-updates-analyzer.md` の Step 4 のみを以下のように改訂:

1. **「前提: 自動適用構成の解釈」セクションを追加** — `autoUpgradeProfile.upgradeChannel` / `nodeOSUpgradeChannel`, `maintenanceConfigurations`, マネージド add-on 群を判定前に確認するよう指示。
2. **カテゴリ定義を改訂**:
   - 🔴: 「CVE を含むコンポーネント更新」を撤去し、retirement / breaking change / 自動適用対象外でユーザー明示操作が必要なものに限定。
   - 🟡: 「CVE 修正を含むマネージド更新も、自動適用構成が有効な範囲では本カテゴリ」と明記。
   - ⚪: 「明示的な有効化設定が無い機能」を含めると明記し、false-positive を抑止。
3. **推奨アクションへの根拠併記**: 🟡 に格下げした項目には、`nodeOSUpgradeChannel` の設定値・メンテナンス窓・実機確認コマンド (`az aks ...` / `kubectl ...`) を併記するよう要求。

個別 add-on 名を Step 3 にハードコードする方針は採用していない (列挙メンテナンスコスト回避)。

## 検証

このブランチを `workflow_dispatch` で実機実行 ([run #26319697817](https://github.com/torumakabe/aks-chaos-lab/actions/runs/26319697817), 約 3 分) し、新 [Issue #164](https://github.com/torumakabe/aks-chaos-lab/issues/164) が生成されたことを確認:

- 「リポジトリの現在構成」テーブルに `Node OS 自動更新チャネル: NodeImage` と `メンテナンスウィンドウ: 毎週水曜 00:00 JST (4時間)` が新たに出力された
- K8s バージョンを 1.34 として正確に検出
- Application Insights Auto-instrumentation GA を「マネージドコンポーネントの自動更新」として 🟡 に分類し、分析メモに判断根拠を明記

なお今回の 14 日間データウィンドウには CVE を含む新規 AKS リリースが存在せず、CVE 系の 🔴 → 🟡 格下げパス自体は直接検証できていない。次回 CVE リリース時に効果が顕現する見込み。

## 補足

- `aks-updates-analyzer.lock.yml` は `{{#runtime-import ...md}}` で .md を実行時に取り込むため再生成不要 (`gh aw compile` でも差分なしを確認)。
- 既に Issue #147 は run #26319697817 の `close-older-issues: true` 設定により自動クローズ済み。

Fixes: #147