### PR TITLE
Remove SLO suffix from service group display name

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -364,7 +364,7 @@ resource azureMonitorSliServiceGroup 'Microsoft.Management/serviceGroups@2024-02
   scope: tenant()
   name: azureMonitorSliServiceGroupName
   properties: {
-    displayName: '${appName} ${environment} SLO'
+    displayName: '${appName} ${environment}'
     parent: {
       resourceId: azureMonitorSliEffectiveParentServiceGroupId
     }


### PR DESCRIPTION
The Service Group is expected to be useful beyond SLO evaluation, so its display name should not imply that it is SLO-specific.

This updates the generated Azure Service Group display name from `${appName} ${environment} SLO` to `${appName} ${environment}` while keeping the stable Service Group resource name and ID unchanged.

Validation:
- `az bicep build --file infra\main.bicep`
- `azd provision --preview base --no-prompt`
- Deployed to azd environment `eval` and confirmed the Service Group display name is `aks-chaos-lab eval`.