### PR TITLE
fix(deps): require patched Starlette

### DIFF
--- a/src/api/pyproject.toml
+++ b/src/api/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
   "opentelemetry-instrumentation-fastapi>=0.62b0,<1.0.0",
   "pydantic>=2.12.5",
   "pydantic-settings>=2.13.1",
-  "starlette>=0.52.1",
+  "starlette>=1.0.1",
 ]
 
 [build-system]


### PR DESCRIPTION
Dependabot updated the lockfile to resolve Starlette to the patched 1.0.1 release, but the project dependency constraint still allowed older versions during future resolution. This change raises the API package's Starlette lower bound so the security update is preserved in source metadata, not just in the current lockfile.

Validation:
- `uv lock --check`
- `uv sync --locked --all-packages`
- `uv run scripts/tasks.py qa-app`