### PR TITLE
feat(infra): make AKS node VM size configurable via env

### DIFF
--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -12,7 +12,7 @@
       "value": "${AZURE_ENV_NAME}"
     },
     "nodeVmSize": {
-      "value": "Standard_D4ds_v5"
+      "value": "${AZURE_AKS_NODE_VM_SIZE:Standard_D4ds_v7}"
     },
     "vnetAddressPrefix": {
       "value": "10.10.0.0/16"


### PR DESCRIPTION
## 概要

AKS ノードの VM サイズをハードコードから環境変数で上書き可能にする。

## 変更内容

`infra/main.parameters.json` の `nodeVmSize` を以下に変更:

- 変更前: `"Standard_D4ds_v5"`（固定）
- 変更後: `"${AZURE_AKS_NODE_VM_SIZE:Standard_D4ds_v7}"`

`AZURE_AKS_NODE_VM_SIZE` で上書きでき、未指定時の既定値は `Standard_D4ds_v7`。環境ごとに VM サイズを切り替えられる。

## 補足

このブランチでの eval 環境デプロイ作業のうち、合意済みの当該変更のみを切り出してコミットしている。SLI no-data の調査結果やその他の作業は本 PR には含めない。