### PR TITLE
feat: support Arm64 AKS node pools and document RBAC prerequisite

### DIFF
--- a/azure.yaml
+++ b/azure.yaml
@@ -70,6 +70,10 @@ services:
     docker:
       path: Dockerfile
       context: ../..
+      # Default build is amd64. azd does not env-expand docker.platform, so to
+      # build for Arm64 node pools (e.g. Standard_D4pds_v6) edit this value to:
+      #   platform: linux/arm64
+      platform: linux/amd64
     hooks:
       predeploy:
         windows:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -43,7 +43,7 @@ managed DCR で `Monitoring Metrics Publisher` が不足すると、SLI の stor
 
 ### 4. AKS の Microsoft Entra 統合
 
-AKS は `aadProfile.managed=true` + `enableAzureRbac=true` + `disableLocalAccounts=true` のため、`kubectl` は Microsoft Entra ID 経由になります。Bicep が deployment 実行 identity に **Azure Kubernetes Service RBAC Cluster Admin** を付与するため、追加のテナント権限は不要です。
+AKS は `aadProfile.managed=true` + `enableAzureRbac=true` + `disableLocalAccounts=true` のため、`kubectl`（`azd up` 中の Kubernetes マニフェスト適用を含む）は Microsoft Entra ID 経由の Azure RBAC で認可されます。`azd up` を実行する identity には、サブスクリプション スコープで **Azure Kubernetes Service RBAC Cluster Admin** を事前に付与してください。
 
 ## プレビュー機能とリソースプロバイダー登録
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -205,8 +205,12 @@ module azureMonitorWorkspace './modules/prometheus/workspace.bicep' = if (enable
 var prometheusWorkspaceResourceId = enablePrometheusWorkspace ? azureMonitorWorkspace.outputs.workspaceId : ''
 var enableExternalSliEffective = enableExternalSliSignals && enablePrometheusWorkspace && enablePrometheusPipeline
 var enableAzureMonitorSliEffective = enableAzureMonitorSli && enableExternalSliEffective
-var normalizedAzureMonitorSliParentServiceGroupId = azureMonitorSliParentServiceGroupId == 'none' ? '' : azureMonitorSliParentServiceGroupId
-var normalizedAzureMonitorSliServiceGroupResourceId = azureMonitorSliServiceGroupResourceId == 'none' ? '' : azureMonitorSliServiceGroupResourceId
+var normalizedAzureMonitorSliParentServiceGroupId = azureMonitorSliParentServiceGroupId == 'none'
+  ? ''
+  : azureMonitorSliParentServiceGroupId
+var normalizedAzureMonitorSliServiceGroupResourceId = azureMonitorSliServiceGroupResourceId == 'none'
+  ? ''
+  : azureMonitorSliServiceGroupResourceId
 var useExistingAzureMonitorSliServiceGroup = !empty(normalizedAzureMonitorSliServiceGroupResourceId)
 var azureMonitorSliServiceGroupNameBase = 'sg-${appName}-${environment}-${resourceToken}'
 var azureMonitorSliServiceGroupName = substring(
@@ -234,7 +238,9 @@ var defaultExternalSliProbeName = substring(
   min(64, length(defaultExternalSliProbeNameBase))
 )
 var effectiveExternalSliProbeName = empty(externalSliProbeName) ? defaultExternalSliProbeName : externalSliProbeName
-var normalizedExternalSliProbePath = startsWith(externalSliProbePath, '/') ? externalSliProbePath : '/${externalSliProbePath}'
+var normalizedExternalSliProbePath = startsWith(externalSliProbePath, '/')
+  ? externalSliProbePath
+  : '/${externalSliProbePath}'
 var externalSliProbeUrl = '${externalSliProbeScheme}://${network.outputs.fqdn}${normalizedExternalSliProbePath}'
 
 module prometheusPipeline './modules/prometheus/pipeline.bicep' = if (enablePrometheusWorkspace && enablePrometheusPipeline) {
@@ -407,7 +413,9 @@ module aksCluster './modules/aks.bicep' = {
 // Separated into a module so principalId (a runtime value) can be passed as a parameter,
 // which makes it a deploy-time value in the module context and usable in guid() for names.
 module alertSubRoleAssignments './modules/alert-sub-role-assignments.bicep' = {
-  name: 'alertSubRoleAssignments'
+  // Subscription-scoped deployment names are keyed by name+location. Suffix with
+  // environment so different regions (dev=eastus2, eval-arm=japaneast) don't collide.
+  name: 'alertSubRoleAssignments-${environment}'
   params: {
     aksAlertPrincipalId: aksCluster.outputs.nodeOsAutoUpgradeAlertPrincipalId
     fleetAlertPrincipalId: fleetManager.outputs.pendingApprovalAlertPrincipalId
@@ -583,7 +591,9 @@ output AZURE_MONITOR_PROMETHEUS_WORKSPACE_ID string = prometheusWorkspaceResourc
 
 @description('Managed Prometheus remote-write URL for external SLI publisher')
 #disable-next-line BCP318
-output AZURE_MONITOR_PROMETHEUS_REMOTE_WRITE_URL string = enableExternalSliEffective ? prometheusPipeline.outputs.prometheusRemoteWriteUrl : ''
+output AZURE_MONITOR_PROMETHEUS_REMOTE_WRITE_URL string = enableExternalSliEffective
+  ? prometheusPipeline.outputs.prometheusRemoteWriteUrl
+  : ''
 
 @description('Azure Managed Redis resource id')
 output AZURE_REDIS_ID string = redisEnterprise.outputs.redisId
@@ -617,28 +627,40 @@ output AZURE_INGRESS_PUBLIC_IP_NAME string = network.outputs.publicIPName
 output AZURE_TENANT_ID string = tenant().tenantId
 
 @description('Azure Service Group resource ID used by Azure Monitor SLI')
-output AZURE_MONITOR_SLI_SERVICE_GROUP_ID string = enableAzureMonitorSliEffective ? azureMonitorSliEffectiveServiceGroupId : ''
+output AZURE_MONITOR_SLI_SERVICE_GROUP_ID string = enableAzureMonitorSliEffective
+  ? azureMonitorSliEffectiveServiceGroupId
+  : ''
 
 @description('Azure Service Group name used by Azure Monitor SLI')
-output AZURE_MONITOR_SLI_SERVICE_GROUP_NAME string = enableAzureMonitorSliEffective ? azureMonitorSliEffectiveServiceGroupName : ''
+output AZURE_MONITOR_SLI_SERVICE_GROUP_NAME string = enableAzureMonitorSliEffective
+  ? azureMonitorSliEffectiveServiceGroupName
+  : ''
 
 @description('Azure Monitor Availability SLI resource name')
-output AZURE_MONITOR_AVAILABILITY_SLI_NAME string = enableAzureMonitorSliEffective ? azureMonitorAvailabilitySliName : ''
+output AZURE_MONITOR_AVAILABILITY_SLI_NAME string = enableAzureMonitorSliEffective
+  ? azureMonitorAvailabilitySliName
+  : ''
 
 @description('Azure Monitor Latency SLI resource name')
 output AZURE_MONITOR_LATENCY_SLI_NAME string = enableAzureMonitorSliEffective ? azureMonitorLatencySliName : ''
 
 @description('Azure Monitor SLI managed identity resource ID')
 #disable-next-line BCP318
-output AZURE_MONITOR_SLI_IDENTITY_ID string = enableAzureMonitorSliEffective ? azureMonitorSliIdentity.outputs.identityId : ''
+output AZURE_MONITOR_SLI_IDENTITY_ID string = enableAzureMonitorSliEffective
+  ? azureMonitorSliIdentity.outputs.identityId
+  : ''
 
 @description('Azure Monitor SLI managed identity client ID')
 #disable-next-line BCP318
-output AZURE_MONITOR_SLI_IDENTITY_CLIENT_ID string = enableAzureMonitorSliEffective ? azureMonitorSliIdentity.outputs.clientId : ''
+output AZURE_MONITOR_SLI_IDENTITY_CLIENT_ID string = enableAzureMonitorSliEffective
+  ? azureMonitorSliIdentity.outputs.clientId
+  : ''
 
 @description('External SLI publisher Function App name')
 #disable-next-line BCP318
-output AZURE_EXTERNAL_SLI_FUNCTION_APP_NAME string = enableExternalSliEffective ? externalSliPublisher.outputs.functionAppName : ''
+output AZURE_EXTERNAL_SLI_FUNCTION_APP_NAME string = enableExternalSliEffective
+  ? externalSliPublisher.outputs.functionAppName
+  : ''
 
 @description('External SLI probe name used in Prometheus labels')
 output AZURE_EXTERNAL_SLI_PROBE_NAME string = enableExternalSliEffective ? effectiveExternalSliProbeName : ''
@@ -648,4 +670,6 @@ output AZURE_EXTERNAL_SLI_PROBE_URL string = enableExternalSliEffective ? extern
 
 @description('External SLI publisher state blob URL')
 #disable-next-line BCP318
-output AZURE_EXTERNAL_SLI_STATE_BLOB_URL string = enableExternalSliEffective ? externalSliPublisher.outputs.stateBlobUrl : ''
+output AZURE_EXTERNAL_SLI_STATE_BLOB_URL string = enableExternalSliEffective
+  ? externalSliPublisher.outputs.stateBlobUrl
+  : ''

--- a/infra/sli/main.bicep
+++ b/infra/sli/main.bicep
@@ -99,11 +99,15 @@ var normalizedResourceGroupName = resourceGroupName == 'none' ? '' : resourceGro
 var normalizedServiceGroupId = serviceGroupId == 'none' ? '' : serviceGroupId
 var normalizedServiceGroupName = serviceGroupName == 'none' ? '' : serviceGroupName
 var normalizedSliIdentityResourceId = sliIdentityResourceId == 'none' ? '' : sliIdentityResourceId
-var normalizedPrometheusWorkspaceResourceId = prometheusWorkspaceResourceId == 'none' ? '' : prometheusWorkspaceResourceId
+var normalizedPrometheusWorkspaceResourceId = prometheusWorkspaceResourceId == 'none'
+  ? ''
+  : prometheusWorkspaceResourceId
 var normalizedAvailabilitySliName = availabilitySliName == 'none' ? '' : availabilitySliName
 var normalizedLatencySliName = latencySliName == 'none' ? '' : latencySliName
 var normalizedActionGroupId = actionGroupId == 'none' ? '' : actionGroupId
-var effectiveResourceGroupName = empty(normalizedResourceGroupName) ? 'rg-${appName}-${environment}' : normalizedResourceGroupName
+var effectiveResourceGroupName = empty(normalizedResourceGroupName)
+  ? 'rg-${appName}-${environment}'
+  : normalizedResourceGroupName
 var effectiveServiceGroupName = !empty(normalizedServiceGroupName)
   ? normalizedServiceGroupName
   : (!empty(normalizedServiceGroupId) ? last(split(normalizedServiceGroupId, '/')) : '')
@@ -116,7 +120,9 @@ var hasSliNames = !empty(normalizedAvailabilitySliName) && !empty(normalizedLate
 var canCreateSli = enabled && hasServiceGroup && hasSliPipeline && hasSliNames
 
 module azureMonitorSliDefinitions '../modules/azmonitor/sli-definitions.bicep' = if (canCreateSli) {
-  name: 'azureMonitorSliDefinitions'
+  // Subscription-scoped deployment name; suffix with environment so different
+  // regions (dev=eastus2, eval-arm=japaneast) don't collide.
+  name: 'azureMonitorSliDefinitions-${environment}'
   params: {
     serviceGroupName: effectiveServiceGroupName
     sliIdentityResourceId: normalizedSliIdentityResourceId
@@ -159,7 +165,9 @@ module azureMonitorSliMetricAlerts '../modules/azmonitor/sli-metric-alerts.bicep
 
 @description('Azure Monitor Availability SLI resource ID')
 #disable-next-line BCP318
-output AZURE_MONITOR_AVAILABILITY_SLI_ID string = canCreateSli ? azureMonitorSliDefinitions.outputs.availabilitySliId : ''
+output AZURE_MONITOR_AVAILABILITY_SLI_ID string = canCreateSli
+  ? azureMonitorSliDefinitions.outputs.availabilitySliId
+  : ''
 
 @description('Azure Monitor Latency SLI resource ID')
 #disable-next-line BCP318
@@ -170,12 +178,18 @@ output AZURE_MONITOR_LATENCY_SLI_THRESHOLD_LE string = latencyThresholdLe
 
 @description('Azure Monitor SLI baseline alert resource IDs')
 #disable-next-line BCP318
-output AZURE_MONITOR_SLI_BASELINE_ALERT_IDS array = canCreateSli && enableSliAlerts ? azureMonitorSliMetricAlerts.outputs.baselineAlertIds : []
+output AZURE_MONITOR_SLI_BASELINE_ALERT_IDS array = canCreateSli && enableSliAlerts
+  ? azureMonitorSliMetricAlerts.outputs.baselineAlertIds
+  : []
 
 @description('Azure Monitor SLI fast burn-rate alert resource IDs')
 #disable-next-line BCP318
-output AZURE_MONITOR_SLI_FAST_BURN_ALERT_IDS array = canCreateSli && enableSliAlerts ? azureMonitorSliMetricAlerts.outputs.fastBurnRateAlertIds : []
+output AZURE_MONITOR_SLI_FAST_BURN_ALERT_IDS array = canCreateSli && enableSliAlerts
+  ? azureMonitorSliMetricAlerts.outputs.fastBurnRateAlertIds
+  : []
 
 @description('Azure Monitor SLI slow burn-rate alert resource IDs')
 #disable-next-line BCP318
-output AZURE_MONITOR_SLI_SLOW_BURN_ALERT_IDS array = canCreateSli && enableSliAlerts ? azureMonitorSliMetricAlerts.outputs.slowBurnRateAlertIds : []
+output AZURE_MONITOR_SLI_SLOW_BURN_ALERT_IDS array = canCreateSli && enableSliAlerts
+  ? azureMonitorSliMetricAlerts.outputs.slowBurnRateAlertIds
+  : []


### PR DESCRIPTION
## 概要

Japan East リージョンで Amd64 系 VM がサブスクリプション制限で割り当てにくい状況に対し、AKS ノードプールの **Arm64 系 VM（Standard_D4pds_v6）** での動作を検証し、その結果と必要な変更を反映する。

## 背景

- Japan East では Intel `D4ds_v7` が未提供で、AMD `D4ads_v7` のみ。これが当初の Amd64 割り当て困難の一因。
- Arm64 系（Dpsv5/v6, Epsv5/v6 等）は提供あり・制限なし・クォータ十分。
- 価格比較: `D4pds_v6`(Arm64) ≈ $0.236/h vs `D4ads_v7`(AMD) ≈ $0.297/h。**Arm64 が約 20% 安い**（ともに 4 vCPU / 16 GiB）。

## 検証結果（新規 azd 環境 `eval-arm` / Japan East）

- ノード 2 台すべて **arm64 / Standard_D4pds_v6 / japaneast**
- コンテナ `uname -m` = **aarch64**
- chaos-app 2 replica Running、Gateway 経由で HTTP 200、レスポンスに Redis データ（Entra ID 認証）
- OTel 環境変数 注入済み、chaos-mesh 一式 Running
- smoke 負荷テスト: 113 req / **失敗 0（0.00%）**、`GET /` p95 53ms

## 変更内容

- **azure.yaml**: api イメージを Arm64 でビルドする方法をコメントで明記。azd は `docker.platform` を環境変数展開しないため、既定は `linux/amd64` のまま。Arm64 ノードプール利用時は値を `linux/arm64` に編集する。
- **infra/main.bicep, infra/sli/main.bicep**: サブスクリプション スコープのデプロイ名に `-${environment}` を付与。固定名だとリージョン違いの複数環境（dev=eastus2, eval-arm=japaneast）で `InvalidDeploymentLocation` 衝突が起きるため。
- **docs/deployment.md**: `azd up` 実行 identity には **Azure Kubernetes Service RBAC Cluster Admin** をサブスクリプション スコープで事前付与する必要がある旨を明確化。

## 補足

- bicep ファイルの diff には品質フック（`az bicep format`）による整形が含まれる。
- `eval-arm` 環境は検証用のため、確認後に `azd down` で削除する想定。