### PR TITLE
Add Inspektor Gadget extension to AKS

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -58,6 +58,7 @@ az feature register --namespace Microsoft.ContainerService --name AzureMonitorAp
 
 # 反映後に provider を再登録
 az provider register --namespace Microsoft.ContainerService
+az provider register --namespace Microsoft.KubernetesConfiguration
 az provider register --namespace Microsoft.Insights
 ```
 
@@ -101,7 +102,7 @@ azd up
 
 `azd up` は `azure.yaml` の `workflows.up` に従い、以下の順で実行されます。
 
-1. `azd provision base` (`infra/main.bicep`) — VNet / AKS / Redis / Application Insights / Managed Prometheus / external SLI publisher infra / Service Group / SLI 用 Managed Identity / RBAC を作成
+1. `azd provision base` (`infra/main.bicep`) — VNet / AKS / Inspektor Gadget 拡張 / Redis / Application Insights / Managed Prometheus / external SLI publisher infra / Service Group / SLI 用 Managed Identity / RBAC を作成
 2. `azd deploy api-instrumentation` — chaos-app 固有の Application Insights OTLP `Instrumentation` を先に適用し、AKS App Monitoring webhook が参照できる状態にする
 3. `azd deploy api` — chaos-app をデプロイし、`postdeploy` hook で Pod に `OTEL_EXPORTER_OTLP_*` が注入されたことを確認
 4. `azd deploy observability` — Envoy Gateway などをデプロイ

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -409,6 +409,14 @@ module aksCluster './modules/aks.bicep' = {
   }
 }
 
+module inspektorGadget './modules/inspektor-gadget.bicep' = {
+  name: 'inspektorGadget'
+  scope: resourceGroup
+  params: {
+    aksClusterName: aksCluster.outputs.aksNameOut
+  }
+}
+
 // Alert role assignments - subscription scope
 // Separated into a module so principalId (a runtime value) can be passed as a parameter,
 // which makes it a deploy-time value in the module context and usable in guid() for names.

--- a/infra/modules/inspektor-gadget.bicep
+++ b/infra/modules/inspektor-gadget.bicep
@@ -1,0 +1,19 @@
+@description('AKS cluster name')
+param aksClusterName string
+
+#disable-next-line BCP081
+resource aksCluster 'Microsoft.ContainerService/managedClusters@2026-03-02-preview' existing = {
+  name: aksClusterName
+}
+
+resource inspektorGadgetExtension 'Microsoft.KubernetesConfiguration/extensions@2025-03-01' = {
+  name: 'inspektor-gadget'
+  scope: aksCluster
+  properties: {
+    extensionType: 'microsoft.inspektorgadget'
+    releaseTrain: 'preview'
+    autoUpgradeMinorVersion: true
+  }
+}
+
+output extensionName string = inspektorGadgetExtension.name


### PR DESCRIPTION
This adds Inspektor Gadget to the lab AKS cluster so low-level eBPF troubleshooting tools are available from the infrastructure deployment.

## Summary

- Adds an unconditional AKS cluster extension module for `microsoft.inspektorgadget` on the preview release train.
- Wires the module into the base Bicep deployment after AKS creation.
- Documents the required `Microsoft.KubernetesConfiguration` provider registration and the base provision scope.

Metrics export is intentionally not enabled in this change.

## Validation

- `az bicep build --file infra\main.bicep`
- `azd env refresh eval --no-prompt`
- `az deployment group what-if` for the Inspektor Gadget module against `eval`
- `az deployment group create` for the Inspektor Gadget module against `eval`
- `az k8s-extension show` returned `provisioningState: Succeeded`
- `kubectl get ds gadget -n gadget` showed `READY 2/2`