### PR TITLE
Update AKS Kubernetes version to 1.35

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -28,7 +28,7 @@ param aksApiSubnetPrefix string = '10.10.3.0/28'
 param functionSubnetPrefix string = '10.10.4.0/26'
 
 @description('Kubernetes version for AKS (x.y or x.y.z).')
-param kubernetesVersion string = '1.34'
+param kubernetesVersion string = '1.35'
 
 @description('AKS SKU mode. Only "Base" is supported in this repository (see ADR-010: AKS Automatic is incompatible with chaos-mesh due to AKS Automatic Deployment Safeguards).')
 @allowed([

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -30,7 +30,7 @@
       "value": "10.10.4.0/26"
     },
     "kubernetesVersion": {
-      "value": "1.34"
+      "value": "1.35"
     },
     "aksSkuName": {
       "value": "${AKS_SKU_NAME:Base}"

--- a/infra/modules/aks.bicep
+++ b/infra/modules/aks.bicep
@@ -5,7 +5,7 @@ param aksName string
 @description('Tags object')
 param tags object = {}
 @description('Kubernetes version (x.y or x.y.z).')
-param kubernetesVersion string = '1.34'
+param kubernetesVersion string = '1.35'
 @description('Node resource group name for AKS managed resources')
 param nodeResourceGroupName string
 @description('Node VM size')


### PR DESCRIPTION
## 背景

AKS の Kubernetes バージョン指定を 1.35 に更新し、検証環境で稼働しているバージョンと IaC の宣言を一致させます。

## 変更内容

トップレベルの Bicep パラメーター、azd のパラメーターファイル、AKS モジュールの既定値をすべて `1.35` に更新します。コントロールプレーンとノードプールには同じバージョン指定が適用されます。

## 確認結果

- `az bicep build --file infra/main.bicep` が完了
- `azd provision base -e eval --no-prompt` で eval 環境へ適用
- AKS の宣言バージョンは `1.35`、実稼働パッチバージョンは `1.35.6`
- 2 ノードが Ready、異常 Pod は 0 件
- `chaos-app` は 2/2 Ready、公開エンドポイント `/` は HTTP 200

初回適用では Azure リソース更新後の postprovision 中に Entra ID Instance Discovery への通信が `EOF` で終了しました。再実行では Azure 側に差分がなく正常終了し、クラスターとワークロードの状態に問題がないことを確認しています。