### PR TITLE
Bicep buildをpre-commitへ移行し更新通知を追加

### DIFF
--- a/.github/agents/review-repo.agent.md
+++ b/.github/agents/review-repo.agent.md
@@ -1,6 +1,6 @@
 ---
 name: review-repo
-description: リポジトリ全体の衛生チェック。instructions の鮮度、ADR/Feature Doc の健全性、追跡衛生、規約整合性を確認する。「リポジトリを点検」「衛生チェック」「hygiene」「priming をレビュー」「instructions を見直して」「review-repo」と言われたら使う。
+description: リポジトリ全体の衛生チェック。instructions とツールの鮮度、ADR/Feature Doc の健全性、追跡衛生、規約整合性を確認する。「リポジトリを点検」「衛生チェック」「hygiene」「priming をレビュー」「instructions を見直して」「review-repo」と言われたら使う。
 ---
 
 リポジトリの衛生状態を包括的にチェックし、問題を報告・修正する。
@@ -116,6 +116,22 @@ az feature show --namespace Microsoft.ContainerService --name AzureMonitorAppMon
 - 必要なら ADR を Superseded / 新規 ADR で置き換え（`manage-adr` 経由）
 
 新しいワークアラウンドを追加する場合は、棚卸しの構造（概要 / 理由 / 場所 / 解消条件 / 確認方法）に揃えて記載する。
+
+### 9. Bicep CLI 固定バージョンの鮮度
+
+`.github/workflows/ci.yml` の `BICEP_VERSION` と、`Azure/bicep` の最新安定リリースを比較する。
+
+```console
+gh api repos/Azure/bicep/releases/latest --jq .tag_name
+```
+
+判定基準:
+
+- CI 固定版が最新安定版と一致 → 問題なし
+- CI 固定版が古い → リリースノートを確認し、Bicep buildとintegration testへの影響を添えて更新を提案する
+- CI 固定版を取得できない、またはGitHub APIに失敗 → バージョン検出処理の問題として報告する
+
+定期検出とIssue通知は `.github/workflows/bicep-version-check.yml` が担う。`review-repo` は固定版を自動更新せず、workflowの存在と検出結果を手動レビュー時に確認する。
 
 ## 出力
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,8 +12,8 @@ AKS 上の Chaos Engineering ラボ環境。azd でインフラとアプリを�
 - **依存**: Redis (Managed, Entra ID auth), Application Insights, Prometheus
 - **パッケージ管理**: uv workspace (ルート `pyproject.toml` + `uv.lock`、`python`/`pip` 直接実行禁止)
 - **品質検証**: ruff + ty + pytest → クリーン環境では `uv run scripts/tasks.py sync-dev` 後に `uv run scripts/tasks.py qa-app`
-- **Bicep 検証**: `az bicep build --file infra/main.bicep`
-- **編集時自動検証**: `.github/hooks/hooks.json` に postToolUse hook を登録。`.py` 編集で workspace ruff (check --fix + format)、`.bicep` 編集で `az bicep format` + `build` を実行し、変更/失敗時はエージェントへ `additionalContext` でフィードバックする
+- **Bicep 検証**: `uv run scripts/tasks.py build-bicep`。Lefthook の pre-commit は、ステージされた Bicep 変更がある場合に実行する
+- **編集時自動検証**: `.github/hooks/hooks.json` に postToolUse hook を登録。`.py` 編集で workspace ruff (check --fix + format)、`.bicep` 編集で `az bicep format` を実行し、変更/失敗時はエージェントへ `additionalContext` でフィードバックする
 
 ## プロジェクト構造
 
@@ -53,7 +53,7 @@ docs/features/    # Feature Document（作業途中の状態保存）
 ## 品質ゲート（必須）
 
 - **Python**: ty エラー 0 件、ruff 警告 0 件、pytest 全テスト合格
-- **Bicep**: `az bicep build` エラー 0 件
+- **Bicep**: `uv run scripts/tasks.py build-bicep` エラー 0 件
 
 ## Windows / cross-shell 注意
 

--- a/.github/hooks/scripts/post-edit-quality-feedback.py
+++ b/.github/hooks/scripts/post-edit-quality-feedback.py
@@ -5,7 +5,7 @@
 
 Runs after edit/create/write tool use:
   *.py    -> ruff check --fix + ruff format (workspace ruff config at the repo root)
-  *.bicep -> az bicep format + az bicep build
+  *.bicep -> az bicep format
 
 When checks modify files or fail, emits additionalContext JSON for Copilot.
 """
@@ -24,14 +24,6 @@ from shutil import which
 COMMAND_TIMEOUT_SEC = 45
 MAX_OUTPUT_CHARS = 1600
 MAX_CONTEXT_CHARS = 4000
-MAX_BICEP_WARNINGS = 10
-
-# Substrings that mark `az bicep build` stderr lines as tool-side notices
-# (e.g. CLI upgrade hints) rather than code diagnostics.
-IGNORE_BICEP_NOTICE_PATTERNS: tuple[str, ...] = (
-    "A new Bicep release is available",
-    "Upgrade now by running",
-)
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 
@@ -85,7 +77,6 @@ def run_command(
     *,
     cwd: Path | None = None,
     timeout_sec: int = COMMAND_TIMEOUT_SEC,
-    capture_stdout: bool = True,
 ) -> CommandResult:
     resolved_command = resolve_command(command)
     env = os.environ.copy()
@@ -95,8 +86,7 @@ def run_command(
         completed = subprocess.run(
             resolved_command,
             cwd=str(cwd) if cwd else None,
-            stdout=subprocess.PIPE if capture_stdout else subprocess.DEVNULL,
-            stderr=subprocess.PIPE,
+            capture_output=True,
             text=True,
             timeout=timeout_sec,
             check=False,
@@ -257,46 +247,7 @@ def _normalize_eol(content: bytes, eol: bytes) -> bytes:
     return unified.replace(b"\n", b"\r\n")
 
 
-def _is_bicep_notice(line: str) -> bool:
-    return any(pattern in line for pattern in IGNORE_BICEP_NOTICE_PATTERNS)
-
-
-def extract_bicep_warnings(result: CommandResult) -> list[str]:
-    """Pick `Warning` diagnostic lines from a successful bicep build run.
-
-    Tool-side notices (CLI upgrade hints, etc.) are filtered out so only
-    actionable code diagnostics surface to the agent.
-    """
-
-    warnings: list[str] = []
-    for raw_line in result.stderr.splitlines():
-        line = raw_line.strip()
-        if not line or "Warning" not in line:
-            continue
-        if _is_bicep_notice(line):
-            continue
-        warnings.append(line)
-
-    if len(warnings) <= MAX_BICEP_WARNINGS:
-        return warnings
-
-    truncated = warnings[:MAX_BICEP_WARNINGS]
-    remaining = len(warnings) - MAX_BICEP_WARNINGS
-    truncated.append(f"(+{remaining} more)")
-    return truncated
-
-
-def warnings_message(path: Path, warnings: list[str]) -> str:
-    joined = "\n".join(warnings)
-    summary = (
-        joined
-        if len(joined) <= MAX_OUTPUT_CHARS
-        else f"{joined[:MAX_OUTPUT_CHARS].rstrip()}..."
-    )
-    return f"Bicep build warnings for `{path}`:\n{summary}"
-
-
-def process_bicep(path: Path) -> list[str]:
+def process_bicep_format(path: Path) -> list[str]:
     before = path.read_bytes()
     original_eol = _detect_eol(before)
     messages: list[str] = []
@@ -310,16 +261,6 @@ def process_bicep(path: Path) -> list[str]:
             preserved = _normalize_eol(formatted, original_eol)
             if preserved != formatted:
                 path.write_bytes(preserved)
-        build_result = run_command(
-            ["az", "bicep", "build", "--file", str(path), "--stdout"],
-            capture_stdout=False,
-        )
-        if build_result.failed:
-            messages.append(failure_message(path, build_result))
-        else:
-            warnings = extract_bicep_warnings(build_result)
-            if warnings:
-                messages.append(warnings_message(path, warnings))
 
     if path.exists() and path.read_bytes() != before:
         messages.append(file_changed_message(path))
@@ -365,7 +306,7 @@ def main() -> None:
     if suffix == ".py":
         messages = process_python(path)
     elif suffix == ".bicep":
-        messages = process_bicep(path)
+        messages = process_bicep_format(path)
 
     emit_additional_context(messages)
 

--- a/.github/workflows/bicep-version-check.yml
+++ b/.github/workflows/bicep-version-check.yml
@@ -1,0 +1,139 @@
+name: Bicep Version Check
+
+on:
+  schedule:
+    # GitHub cron cannot express the first Monday directly. The first step
+    # skips the remaining Mondays.
+    - cron: "17 0 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  check:
+    name: Check latest stable version
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Select first Monday
+        id: schedule
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          run=false
+          day="$(date -u +%d)"
+          if [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]] || (( 10#$day <= 7 )); then
+            run=true
+          fi
+
+          echo "run=$run" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout
+        if: steps.schedule.outputs.run == 'true'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Compare Bicep CLI versions
+        if: steps.schedule.outputs.run == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_TITLE: Bicep CLIのCI固定バージョンを更新する
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          mapfile -t current_versions < <(
+            sed -nE 's/^[[:space:]]*BICEP_VERSION=v([^[:space:]]+)[[:space:]]*$/\1/p' \
+              .github/workflows/ci.yml
+          )
+          if (( ${#current_versions[@]} != 1 )); then
+            echo "::error::Expected exactly one BICEP_VERSION in .github/workflows/ci.yml"
+            exit 1
+          fi
+
+          current="${current_versions[0]}"
+          latest_tag="$(gh api repos/Azure/bicep/releases/latest --jq '.tag_name')"
+          if [[ ! "$current" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]] ||
+             [[ ! "$latest_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error::Unexpected Bicep version: current=$current latest=$latest_tag"
+            exit 1
+          fi
+          latest="${latest_tag#v}"
+          tick='`'
+
+          issue_record="$(
+            gh issue list \
+              --repo "$GITHUB_REPOSITORY" \
+              --state all \
+              --limit 100 \
+              --json number,state,title |
+              jq -r \
+                --arg title "$ISSUE_TITLE" \
+                '[.[] | select(.title == $title) | "\(.number) \(.state)"][0] // empty'
+          )"
+          issue_number="${issue_record%% *}"
+          issue_state="${issue_record#* }"
+
+          if [[ "$current" == "$latest" ]]; then
+            result="latest"
+          elif [[ "$(printf '%s\n%s\n' "$current" "$latest" | sort -V | head -n 1)" == "$current" ]]; then
+            result="outdated"
+          else
+            result="ahead"
+          fi
+
+          {
+            echo "## Bicep CLI version check"
+            echo
+            echo "| CI fixed version | Latest stable version | Result |"
+            echo "|---|---|---|"
+            echo "| ${tick}${current}${tick} | ${tick}${latest}${tick} | ${tick}${result}${tick} |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          if [[ "$result" == "outdated" ]]; then
+            body="$(cat <<EOF
+          ## Bicep CLI バージョン
+
+          | 対象 | バージョン |
+          |---|---|
+          | CI 固定版 | ${tick}${current}${tick} |
+          | 最新安定版 | ${tick}${latest}${tick} |
+
+          [Bicep v$latest のリリースノート](https://github.com/Azure/bicep/releases/tag/v$latest)を確認し、${tick}.github/workflows/ci.yml${tick} の ${tick}BICEP_VERSION${tick} を更新してください。更新時はBicep buildとintegration testへの影響を確認します。
+
+          このIssueは ${tick}bicep-version-check.yml${tick} が管理します。CI固定版が最新安定版へ追従すると自動的に閉じます。
+          EOF
+          )"
+
+            if [[ -n "$issue_number" ]]; then
+              gh api \
+                --method PATCH \
+                "repos/$GITHUB_REPOSITORY/issues/$issue_number" \
+                -f body="$body" \
+                -f state=open \
+                > /dev/null
+            else
+              gh api \
+                --method POST \
+                "repos/$GITHUB_REPOSITORY/issues" \
+                -f title="$ISSUE_TITLE" \
+                -f body="$body" \
+                > /dev/null
+            fi
+          elif [[ -n "$issue_number" && "$issue_state" == "OPEN" ]]; then
+            if [[ "$result" == "latest" ]]; then
+              close_message="CI固定版 ${tick}${current}${tick} は最新安定版 ${tick}${latest}${tick} に追従しました。"
+            else
+              close_message="CI固定版 ${tick}${current}${tick} は最新安定版 ${tick}${latest}${tick} より新しいため、更新通知を閉じます。"
+            fi
+            gh issue comment \
+              "$issue_number" \
+              --repo "$GITHUB_REPOSITORY" \
+              --body "$close_message"
+            gh issue close \
+              "$issue_number" \
+              --repo "$GITHUB_REPOSITORY" \
+              --reason completed
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,19 @@ jobs:
         run: uv run scripts/tasks.py sync-dev
       - name: Run unit tests with coverage
         run: uv run scripts/tasks.py test
+      - name: Install Lefthook
+        run: |
+          set -euxo pipefail
+          LEFTHOOK_VERSION=2.1.10
+          LEFTHOOK_SHA256=0b14162a0bb2f0c64ae0759f6102f6e19c4d00981666a8ac73d4f5a6878ada4f
+          mkdir -p "$HOME/.local/bin"
+          curl -fsSL -o /tmp/lefthook.gz "https://github.com/evilmartians/lefthook/releases/download/v${LEFTHOOK_VERSION}/lefthook_${LEFTHOOK_VERSION}_Linux_x86_64.gz"
+          echo "${LEFTHOOK_SHA256}  /tmp/lefthook.gz" | sha256sum -c -
+          gzip -dc /tmp/lefthook.gz > "$HOME/.local/bin/lefthook"
+          chmod +x "$HOME/.local/bin/lefthook"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+      - name: Test Git hooks
+        run: uv run scripts/tasks.py test-hooks
   bicep:
     name: Bicep Build
     runs-on: ubuntu-latest

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -147,8 +147,11 @@ azd env set AZURE_AKS_NODE_VM_SIZE Standard_D4pds_v6 -e eval
 
 ```bash
 uv run scripts/tasks.py sync-dev
+lefthook install
 uv run scripts/tasks.py run
 ```
+
+`lefthook install` は、コントリビュータ向けにこのリポジトリの Git hooks を登録します。ステージされた `infra/` 配下の Bicep ファイルがある場合、pre-commit は `infra/main.bicep` をビルドし、失敗したコミットを中止します。Lefthook のインストール方法は [公式手順](https://lefthook.dev/install/) を参照してください。
 
 ## テストと品質確認
 
@@ -162,6 +165,18 @@ uv run scripts/tasks.py test-cov
 uv run scripts/tasks.py lint
 uv run scripts/tasks.py typecheck
 uv run scripts/tasks.py qa-app
+```
+
+Bicep:
+
+```bash
+uv run scripts/tasks.py build-bicep
+```
+
+Git hooks:
+
+```bash
+uv run scripts/tasks.py test-hooks
 ```
 
 リポジトリ全体:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,5 @@
+pre-commit:
+  commands:
+    bicep-build:
+      glob: "{infra/*.bicep,infra/**/*.bicep}"
+      run: uv run scripts/tasks.py build-bicep

--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -206,6 +206,13 @@ def target_test_publisher() -> None:
     print_success("External SLI publisher unit tests passed")
 
 
+def target_test_hooks() -> None:
+    print_step("Testing repository hooks")
+    target_check_lefthook()
+    run_uv(["pytest", "scripts/tests/test_lefthook.py", "-q"])
+    print_success("Repository hook tests passed")
+
+
 def target_test() -> None:
     target_test_api()
     target_test_publisher()
@@ -272,7 +279,7 @@ def target_qa_scripts() -> None:
     print_success("Scripts QA passed")
 
 
-def target_lint_bicep() -> None:
+def target_build_bicep() -> None:
     target_check_az()
     print_step("Building Bicep template infra/main.bicep")
     run(["az", "bicep", "build", "--file", "infra/main.bicep"])
@@ -311,7 +318,7 @@ def target_lint_k8s() -> None:
 
 
 def target_qa_platform() -> None:
-    target_lint_bicep()
+    target_build_bicep()
     target_lint_k8s()
     print_success("Platform QA passed")
 
@@ -391,10 +398,16 @@ def target_check_gh_aw() -> None:
     run(["gh", "aw", "--version"], check=True)
 
 
+def target_check_lefthook() -> None:
+    require_command("lefthook")
+    run(["lefthook", "validate"])
+
+
 def target_install_tools() -> None:
     target_check_docker()
     target_check_az()
     target_check_gh_aw()
+    target_check_lefthook()
     print_success("All required external tools are available")
 
 
@@ -658,10 +671,12 @@ def target_test_load() -> None:
 
 TARGETS: dict[str, Callable[[], None]] = {
     "build": target_build,
+    "build-bicep": target_build_bicep,
     "check": target_check,
     "check-az": target_check_az,
     "check-docker": target_check_docker,
     "check-gh-aw": target_check_gh_aw,
+    "check-lefthook": target_check_lefthook,
     "check-publisher-requirements": target_check_publisher_requirements,
     "check-uv-version": target_check_uv_version,
     "clean": target_clean,
@@ -672,7 +687,6 @@ TARGETS: dict[str, Callable[[], None]] = {
     "install": target_install,
     "install-tools": target_install_tools,
     "lint": target_lint,
-    "lint-bicep": target_lint_bicep,
     "lint-check": target_lint_check,
     "lint-k8s": target_lint_k8s,
     "lint-workflows": target_lint_workflows,
@@ -693,6 +707,7 @@ TARGETS: dict[str, Callable[[], None]] = {
     "test-api": target_test_api,
     "test-cov": target_test_cov,
     "test-integration": target_test_integration,
+    "test-hooks": target_test_hooks,
     "test-load": target_test_load,
     "test-publisher": target_test_publisher,
     "typecheck": target_typecheck,

--- a/scripts/tests/test_lefthook.py
+++ b/scripts/tests/test_lefthook.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def _required_command(name: str) -> str:
+    command = shutil.which(name)
+    if command is None:
+        pytest.fail(f"{name} is required to run repository hook tests", pytrace=False)
+    return command
+
+
+def _fake_uv(tmp_path: Path) -> None:
+    shell_executable = tmp_path / "uv"
+    shell_executable.write_text(
+        '#!/bin/sh\nprintf "%s\\n" "$*" >> "$HOOK_TEST_LOG"\n',
+        encoding="utf-8",
+    )
+    shell_executable.chmod(0o755)
+
+    if os.name == "nt":
+        cmd_executable = tmp_path / "uv.cmd"
+        cmd_executable.write_text(
+            '@echo off\r\necho %*>>"%HOOK_TEST_LOG%"\r\n',
+            encoding="utf-8",
+        )
+
+
+@pytest.mark.parametrize(
+    ("file_path", "should_run"),
+    [
+        ("infra/main.bicep", True),
+        ("infra/modules/redis.bicep", True),
+        ("README.md", False),
+    ],
+)
+def test_bicep_pre_commit_selection(
+    tmp_path: Path,
+    file_path: str,
+    *,
+    should_run: bool,
+) -> None:
+    lefthook = _required_command("lefthook")
+
+    _fake_uv(tmp_path)
+    log_path = tmp_path / "uv.log"
+    env = os.environ.copy()
+    env["HOOK_TEST_LOG"] = str(log_path)
+    env["PATH"] = os.pathsep.join((str(tmp_path), env["PATH"]))
+
+    completed = subprocess.run(
+        [
+            lefthook,
+            "run",
+            "pre-commit",
+            "--file",
+            file_path,
+            "--no-tty",
+        ],
+        cwd=ROOT,
+        env=env,
+        check=False,
+        capture_output=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    calls = (
+        log_path.read_text(encoding="utf-8").splitlines() if log_path.exists() else []
+    )
+    expected = ["run scripts/tasks.py build-bicep"] if should_run else []
+    assert calls == expected
+
+
+def test_bicep_pre_commit_uses_staged_files(tmp_path: Path) -> None:
+    git = _required_command("git")
+    lefthook = _required_command("lefthook")
+    repository = tmp_path / "repository"
+    fake_bin = tmp_path / "bin"
+    repository.mkdir()
+    fake_bin.mkdir()
+
+    subprocess.run(
+        [git, "init", "--quiet"],
+        cwd=repository,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    shutil.copyfile(ROOT / "lefthook.yml", repository / "lefthook.yml")
+    (repository / "README.md").write_text("test\n", encoding="utf-8")
+    bicep_path = repository / "infra" / "main.bicep"
+    bicep_path.parent.mkdir()
+    bicep_path.write_text("targetScope = 'subscription'\n", encoding="utf-8")
+
+    _fake_uv(fake_bin)
+    log_path = tmp_path / "uv.log"
+    env = os.environ.copy()
+    env["HOOK_TEST_LOG"] = str(log_path)
+    env["PATH"] = os.pathsep.join((str(fake_bin), env["PATH"]))
+
+    subprocess.run(
+        [git, "add", "README.md"],
+        cwd=repository,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    unstaged_result = subprocess.run(
+        [lefthook, "run", "pre-commit", "--no-tty"],
+        cwd=repository,
+        env=env,
+        check=False,
+        capture_output=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    assert unstaged_result.returncode == 0, unstaged_result.stderr
+    assert not log_path.exists()
+
+    subprocess.run(
+        [git, "add", "infra/main.bicep"],
+        cwd=repository,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    staged_result = subprocess.run(
+        [lefthook, "run", "pre-commit", "--no-tty"],
+        cwd=repository,
+        env=env,
+        check=False,
+        capture_output=True,
+        encoding="utf-8",
+        errors="replace",
+    )
+    assert staged_result.returncode == 0, staged_result.stderr
+    assert log_path.read_text(encoding="utf-8").splitlines() == [
+        "run scripts/tasks.py build-bicep"
+    ]


### PR DESCRIPTION
## 背景

Copilotの編集後フックでBicep buildを毎回実行していたため、ファイル操作のたびに不要な検証コストが発生していました。また、通常CIが固定するBicep CLIとローカル環境のバージョン差を検出する仕組みがありませんでした。

## 変更内容

- 編集後フックはBicep formatだけを実行し、buildをLefthookのpre-commitへ移動
- `lint-bicep`を実態に合う`build-bicep`へ改名し、`qa-platform`とpre-commitで同じ入口を使用
- ルート直下とサブディレクトリのBicep変更を対象にし、実際のステージ状態を含む回帰テストをCIへ追加
- CI固定版とBicep最新安定版を月次で比較し、古い場合だけ単一Issueを作成または再オープンする非ブロッキングworkflowを追加
- `review-repo`の手動点検へBicep CLI固定版の鮮度確認を追加

## 注意点

バージョン確認workflowは毎週月曜に起動し、UTCの日付が1日から7日の場合だけ処理することで第1月曜を選択します。手動実行時は日付にかかわらず処理します。

このworkflowはBicep CLIを自動更新せず、通常CIも停止しません。CI固定版が最新安定版へ追従すると通知Issueを閉じます。

## 検証

- `uv run scripts/tasks.py test-hooks`
- `uv run scripts/tasks.py lint-workflows`
- `uv run scripts/tasks.py build-bicep`
- `uv run scripts/tasks.py qa-app`
- `lefthook validate`
- Windowsでhookテストを警告エラー化して実行
- Bicepバージョン比較のoutdated、latest、ahead各ケースを確認