### PR TITLE
Support approved package indexes with a public uv lock

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -29,7 +29,9 @@
 docs/
 infra/
 k8s/
-scripts/
+scripts/*
+!scripts/approved_index_config.py
+!scripts/public_lock.py
 tests/
 # Exclude publisher source/tests but keep its pyproject.toml so the Dockerfile
 # can resolve the workspace lockfile (uv requires every member's manifest).

--- a/.github/agents/review-repo.agent.md
+++ b/.github/agents/review-repo.agent.md
@@ -50,7 +50,7 @@ git で追跡されているファイルに、追跡すべきでないものが�
 
 品質ゲートが通るか確認する:
 
-- Python: クリーン環境では `uv run scripts/tasks.py sync-dev` 後に `uv run scripts/tasks.py qa-app`（ruff + ty + pytest）
+- Python: クリーン環境では `uv run --no-project "${PWD}/scripts/tasks.py" sync-dev` 後に `uv run --no-project "${PWD}/scripts/tasks.py" qa-app`（ruff + ty + pytest）
 - Bicep: `az bicep build --file infra/main.bicep`
 
 ### 4. ADR 健全性

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,10 +10,10 @@ AKS 上の Chaos Engineering ラボ環境。azd でインフラとアプリを�
 - **IaC**: Bicep, subscription scope (`infra/`)
 - **K8s**: Kustomize (`k8s/`)
 - **依存**: Redis (Managed, Entra ID auth), Application Insights, Prometheus
-- **パッケージ管理**: uv workspace (ルート `pyproject.toml` + `uv.lock`、`python`/`pip` 直接実行禁止)
-- **品質検証**: ruff + ty + pytest → クリーン環境では `uv run scripts/tasks.py sync-dev` 後に `uv run scripts/tasks.py qa-app`
-- **Bicep 検証**: `uv run scripts/tasks.py build-bicep`。Lefthook の pre-commit は、ステージされた Bicep 変更がある場合に実行する
-- **編集時自動検証**: `.github/hooks/hooks.json` に postToolUse hook を登録。`.py` 編集で workspace ruff (check --fix + format)、`.bicep` 編集で `az bicep format` を実行し、変更/失敗時はエージェントへ `additionalContext` でフィードバックする
+- **パッケージ管理**: uv 0.12.2 の workspace (ルート `pyproject.toml` + public PyPI source の `uv.lock`、`python`/`pip` 直接実行禁止)
+- **品質検証**: ruff + ty + pytest → クリーン環境では通常は `uv run --no-project "${PWD}/scripts/tasks.py" sync-dev`、組織承認済み package index を必須とする環境では `uv run --no-project "${PWD}/scripts/tasks.py" sync-dev-approved-index` の後に `uv run --no-project "${PWD}/scripts/tasks.py" qa-app`
+- **Bicep 検証**: `uv run --no-project "${PWD}/scripts/tasks.py" build-bicep`。Lefthook の pre-commit は、ステージされた Bicep 変更がある場合に実行する
+- **編集時自動検証**: `.github/hooks/hooks.json` に postToolUse hook を登録。`.py` 編集では project `.venv` の ruff を直接実行し、`.bicep` 編集では `az bicep format` を実行する。変更/失敗時はエージェントへ `additionalContext` でフィードバックする。依存関係の整合性は同期taskとCIが検証する
 
 ## プロジェクト構造
 
@@ -22,7 +22,7 @@ pyproject.toml    # uv workspace ルート (ruff/ty 共通設定、開発用依�
 uv.lock           # workspace 共通ロック
 src/api/          # FastAPI アプリ (uv member: aks-chaos-lab-api)
 src/api/app/      # main.py, config.py, models.py, redis_client.py 等
-src/api/Dockerfile # build context = repo root, `uv sync --package aks-chaos-lab-api`
+src/api/Dockerfile # build context = repo root, `uv export` + `uv pip sync` で API 依存を導入
 src/external-sli-publisher/  # Azure Functions publisher (uv member, デプロイは requirements.txt)
 infra/modules/    # Bicep モジュール (aks, network, redis, acr, identity, chaos 等)
 k8s/apps/chaos-app/ # chaos-app Kustomize マニフェスト
@@ -53,11 +53,11 @@ docs/features/    # Feature Document（作業途中の状態保存）
 ## 品質ゲート（必須）
 
 - **Python**: ty エラー 0 件、ruff 警告 0 件、pytest 全テスト合格
-- **Bicep**: `uv run scripts/tasks.py build-bicep` エラー 0 件
+- **Bicep**: `uv run --no-project "${PWD}/scripts/tasks.py" build-bicep` エラー 0 件
 
 ## Windows / cross-shell 注意
 
-- Windows で Locust 負荷テストを実行する場合は、`uv run locust ...` を直接使わず `uv run scripts/tasks.py load-*` を使う。wrapper が child process に `PYTHONUTF8=1` を設定し、cp932 などの既定 encoding による TOML 読み取り失敗を避ける。
+- Windows で Locust 負荷テストを実行する場合は、`uv run locust ...` を直接使わず `uv run --no-project "${PWD}/scripts/tasks.py" load-*` を使う。wrapper が child process に `PYTHONUTF8=1` を設定し、cp932 などの既定 encoding による TOML 読み取り失敗を避ける。
 - Locust CSV 出力は `LOCUST_CSV_PREFIX` と、必要な場合のみ `LOCUST_CSV_FULL_HISTORY=true` で指定する。任意引数を広く通す `LOCUST_EXTRA_ARGS` のような仕組みは追加しない。
 - WSL / bash helper に Windows path を渡す場合は、`C:\...` ではなく `/mnt/c/...` 形式へ変換する。PowerShell / Windows native shell では `C:\...` 形式を使う。
 

--- a/.github/hooks/hooks.json
+++ b/.github/hooks/hooks.json
@@ -4,8 +4,8 @@
     "postToolUse": [
       {
         "type": "command",
-        "bash": "uv run .github/hooks/scripts/post-edit-quality-feedback.py",
-        "powershell": "uv run .github/hooks/scripts/post-edit-quality-feedback.py",
+        "bash": "uv run --no-project \"${PWD}/.github/hooks/scripts/post-edit-quality-feedback.py\"",
+        "powershell": "uv run --no-project \"${PWD}/.github/hooks/scripts/post-edit-quality-feedback.py\"",
         "timeoutSec": 60
       }
     ]

--- a/.github/hooks/scripts/post-edit-quality-feedback.py
+++ b/.github/hooks/scripts/post-edit-quality-feedback.py
@@ -42,6 +42,12 @@ class CommandResult:
         return self.timed_out or self.returncode is None or self.returncode != 0
 
 
+def project_ruff_path() -> Path:
+    if os.name == "nt":
+        return REPO_ROOT / ".venv" / "Scripts" / "ruff.exe"
+    return REPO_ROOT / ".venv" / "bin" / "ruff"
+
+
 def to_text(value: str | bytes | None) -> str:
     if value is None:
         return ""
@@ -219,10 +225,27 @@ def process_python(path: Path) -> list[str]:
 
     before = absolute.read_bytes()
     messages: list[str] = []
+    ruff = project_ruff_path()
+    if not ruff.is_file():
+        return [
+            "The project virtual environment does not contain ruff. Run the "
+            "appropriate sync target before editing Python files."
+        ]
 
     for command in (
-        ["uv", "run", "ruff", "check", "--fix", "--quiet", str(absolute)],
-        ["uv", "run", "ruff", "format", "--quiet", str(absolute)],
+        [
+            str(ruff),
+            "check",
+            "--fix",
+            "--quiet",
+            str(absolute),
+        ],
+        [
+            str(ruff),
+            "format",
+            "--quiet",
+            str(absolute),
+        ],
     ):
         result = run_command(command, cwd=REPO_ROOT)
         if result.failed:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,22 @@ permissions:
   contents: read
 
 jobs:
+  lock:
+    name: uv Lock Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Setup uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          version-file: "pyproject.toml"
+          python-version: "3.14"
+      - name: Check lock consistency
+        run: uv lock --check
+      - name: Check lock package sources
+        run: uv run --no-project "${{ github.workspace }}/scripts/tasks.py" check-public-lock
+
   format:
     name: Ruff Format Check
     runs-on: ubuntu-latest
@@ -21,9 +37,9 @@ jobs:
           version-file: "pyproject.toml"
           python-version: "3.14"
       - name: Sync deps (dev)
-        run: uv run scripts/tasks.py sync-dev
+        run: uv run --no-project "${{ github.workspace }}/scripts/tasks.py" sync-dev
       - name: Ruff format check
-        run: uv run scripts/tasks.py format-check
+        run: uv run --no-project "${{ github.workspace }}/scripts/tasks.py" format-check
   lint:
     name: Ruff Lint
     runs-on: ubuntu-latest
@@ -36,9 +52,9 @@ jobs:
           version-file: "pyproject.toml"
           python-version: "3.14"
       - name: Sync deps (dev)
-        run: uv run scripts/tasks.py sync-dev
+        run: uv run --no-project "${{ github.workspace }}/scripts/tasks.py" sync-dev
       - name: Ruff check
-        run: uv run scripts/tasks.py lint-check
+        run: uv run --no-project "${{ github.workspace }}/scripts/tasks.py" lint-check
 
   typecheck:
     name: ty Typecheck
@@ -52,9 +68,9 @@ jobs:
           version-file: "pyproject.toml"
           python-version: "3.14"
       - name: Sync deps (dev)
-        run: uv run scripts/tasks.py sync-dev
+        run: uv run --no-project "${{ github.workspace }}/scripts/tasks.py" sync-dev
       - name: ty check
-        run: uv run scripts/tasks.py typecheck
+        run: uv run --no-project "${{ github.workspace }}/scripts/tasks.py" typecheck
   tests:
     name: Pytest
     runs-on: ubuntu-latest
@@ -67,9 +83,9 @@ jobs:
           version-file: "pyproject.toml"
           python-version: "3.14"
       - name: Sync deps (dev)
-        run: uv run scripts/tasks.py sync-dev
+        run: uv run --no-project "${{ github.workspace }}/scripts/tasks.py" sync-dev
       - name: Run unit tests with coverage
-        run: uv run scripts/tasks.py test
+        run: uv run --no-project "${{ github.workspace }}/scripts/tasks.py" test
       - name: Install Lefthook
         run: |
           set -euxo pipefail
@@ -82,7 +98,7 @@ jobs:
           chmod +x "$HOME/.local/bin/lefthook"
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
       - name: Test Git hooks
-        run: uv run scripts/tasks.py test-hooks
+        run: uv run --no-project "${{ github.workspace }}/scripts/tasks.py" test-hooks
   bicep:
     name: Bicep Build
     runs-on: ubuntu-latest

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -196,6 +196,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          version-file: "pyproject.toml"
 
       - name: Smoke test - Health endpoint
         env:

--- a/.github/workflows/refresh-uv-lock.yml
+++ b/.github/workflows/refresh-uv-lock.yml
@@ -2,6 +2,11 @@ name: Refresh public uv lock
 
 on:
   workflow_dispatch:
+  pull_request:
+    paths:
+      - .github/workflows/refresh-uv-lock.yml
+      - pyproject.toml
+      - uv.lock
 
 permissions:
   contents: read

--- a/.github/workflows/refresh-uv-lock.yml
+++ b/.github/workflows/refresh-uv-lock.yml
@@ -1,0 +1,33 @@
+name: Refresh public uv lock
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  refresh-lock:
+    name: Generate public uv.lock
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Setup uv
+        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        with:
+          version-file: "pyproject.toml"
+          python-version: "3.14"
+      - name: Refresh lock
+        run: uv lock
+      - name: Check lock consistency
+        run: uv lock --check
+      - name: Check lock package sources
+        run: uv run --no-project "${{ github.workspace }}/scripts/tasks.py" check-public-lock
+      - name: Upload public lock
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: uv-lock-public
+          path: uv.lock
+          if-no-files-found: error
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -110,6 +110,7 @@ ipython_config.py
 #   This is especially recommended for binary packages to ensure reproducibility, and is more
 #   commonly ignored for libraries.
 #uv.lock
+.uv-state/
 
 # poetry
 #   Similar to Pipfile.lock, it is generally recommended to include poetry.lock in version control.

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -4,31 +4,31 @@
     {
       "label": "sync-dev",
       "type": "shell",
-      "command": "uv run scripts/tasks.py sync-dev",
+      "command": "uv run --no-project \"${workspaceFolder}/scripts/tasks.py\" sync-dev",
       "group": "build"
     },
     {
       "label": "test",
       "type": "shell",
-      "command": "uv run scripts/tasks.py test",
+      "command": "uv run --no-project \"${workspaceFolder}/scripts/tasks.py\" test",
       "group": "build"
     },
     {
       "label": "lint",
       "type": "shell",
-      "command": "uv run scripts/tasks.py lint",
+      "command": "uv run --no-project \"${workspaceFolder}/scripts/tasks.py\" lint",
       "group": "build"
     },
     {
       "label": "typecheck",
       "type": "shell",
-      "command": "uv run scripts/tasks.py typecheck",
+      "command": "uv run --no-project \"${workspaceFolder}/scripts/tasks.py\" typecheck",
       "group": "build"
     },
     {
       "label": "qa",
       "type": "shell",
-      "command": "uv run scripts/tasks.py qa",
+      "command": "uv run --no-project \"${workspaceFolder}/scripts/tasks.py\" qa",
       "group": "build"
     }
   ]

--- a/README.md
+++ b/README.md
@@ -87,8 +87,15 @@ azd up
 ローカル開発と検証:
 
 ```bash
-uv run scripts/tasks.py sync-dev
-uv run scripts/tasks.py qa
+uv run --no-project "${PWD}/scripts/tasks.py" sync-dev
+uv run --no-project "${PWD}/scripts/tasks.py" qa
+```
+
+public package registry へ直接接続できず、組織承認済みの Python package index を使う環境では、代わりに次の同期タスクを実行します。
+
+```bash
+uv run --no-project "${PWD}/scripts/tasks.py" sync-dev-approved-index
+uv run --no-project "${PWD}/scripts/tasks.py" qa
 ```
 
 環境削除:
@@ -128,7 +135,7 @@ docs/features/       セッションをまたぐ Feature Document
 .github/hooks/       Copilot CLI postToolUse 用 lint/format フィードバック
 ```
 
-> Python は uv workspace 構成です。ルートで `uv sync --all-packages --all-groups` を一度実行すれば、`src/api` と `src/external-sli-publisher` の両方の依存と開発ツール (ruff / ty / pytest) が揃います。詳細は [ADR-013](docs/adr/013-uv-workspace-unified-tooling.md) を参照。
+> Python は uv workspace 構成です。ルートで同期すれば、`src/api` と `src/external-sli-publisher` の両方の依存と開発ツール (ruff / ty / pytest) が揃います。通常の同期は [ADR-013](docs/adr/013-uv-workspace-unified-tooling.md)、組織承認済み package index を使う環境は [ADR-017](docs/adr/017-approved-index-conversion-for-managed-environments.md) を参照してください。
 
 ## ライセンス
 

--- a/docs/adr/017-approved-index-conversion-for-managed-environments.md
+++ b/docs/adr/017-approved-index-conversion-for-managed-environments.md
@@ -1,0 +1,31 @@
+# ADR-017: 管理対象環境向け approved-index 変換フロー (ADR-013 の一部を amend)
+
+- Status: Accepted
+- Date: 2026-08-08
+
+## Context
+Public GitHub repository では public PyPI source の root `uv.lock` を唯一の正本とする。一方、public PyPI へ直接アクセスできず、organization-approved package index の使用を必須とする管理対象環境では、ADR-013 の依存関係同期方式を適用できない。
+
+## Decision
+1. Public GitHub repository では public PyPI source の root `uv.lock` を唯一の正本として維持する。
+2. 管理対象環境では、user-level uv configが単一の`[[index]]`と`default = true`を持つことを検査する。index source、find-links、hash検証、TLS検証、projectまたはdependency groupを変更する設定と環境変数がある場合は同期を中止する。exportと後続の`uv run`はroot projectと対象venvの絶対pathへ固定する。
+3. 管理対象環境ではpublic lockのsourceを検査し、`uv export --frozen`で未コミットの一時requirementsへ変換する。変換後のrequirementsも検査してdirect URLを拒否し、registry packageへ`--require-hashes`を適用してapproved-indexから環境を構築する。workspace sourceはindexを介さず参照する。通常環境とは別のuv cacheを使い、過去にpublic PyPIから取得したartifactを再利用しない。approved-indexがpublic lockの許可するbit-identical artifactを提供することを成立条件とする。
+4. sync stateは仮想環境の外に置き、`uv.lock`のSHA-256と状態（in-progressまたはready）を保持する。環境を消去する前にin-progressを書き、同期の開始時と完了時でlockのhashが一致した場合だけreadyへ変更する。ready stateと同じprovenance markerを仮想環境内にも保存し、両者が一致する場合だけ環境を使用する。staleまたはincompleteの場合はfail closedで再同期を要求し、public sourceへ自動fallbackしない。
+5. task runnerはscriptの絶対pathと`uv run --no-project`で起動し、taskのstate検査より前に別のprojectを探索または同期しないようにする。
+6. GitHub Actions、Azure Functions remote build、外部利用者はpublic PyPIを継続して使用する。
+7. Docker buildも同じexportとpip syncを使う。管理対象環境のローカルbuildはbuild argumentでapproved-index modeとconfigのSHA-256を明示し、BuildKit secretでuser-level uv configをmountする。Dockerfileはmountしたconfigのhashを照合し、build modeとhashをdependency layerおよびBuildKit cache mountのkeyへ含める。公開CIにはsecretを渡さない。
+8. uvはhost、CI、Dockerのすべてで`0.12.2`にexact pinする。
+9. dependency update時のpublic lockはGitHub Actionsのread-only artifact workflowで生成し、botのcommit permissionまたはwrite permissionを使わない。
+10. ADR-013のroot lock一本化、Dockerのuv sync、post-edit hookの自動sync許可を上記方式へamendする。post-edit hookは依存関係の整合性を判定せず、project venvのruffを直接実行する。uv workspaceによる統一とADR-009/012のdeploy単位分離は維持する。
+
+## Consequences
+- 管理対象環境は public lock と bit-identical な依存関係を再現できる。
+- 一時 requirements と sync state の管理が増える。approved-index が成立条件を満たさない場合、環境構築は失敗する。
+
+## 採用しなかった代替案
+- **管理対象環境専用の lock**: 正本が二重化するため採用しない。
+- **approved-index への正本移行または public source への fallback**: 公開利用者へ組織固有の設定を課すか、管理対象環境の制約を回避するため採用しない。
+
+## 関連 ADR
+- ADR-013: 依存関係同期の該当部分を amend し、workspace 統一を維持する。
+- ADR-009、ADR-012: deploy 単位分離を維持する。

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -14,7 +14,8 @@
 | 010 | [AKS Automatic は本リポジトリで非サポート (Deployment Safeguards が chaos-mesh と非互換)](010-aks-automatic-unsupported-due-to-deployment-safeguards.md) | Accepted | 2026-05-06 |
 | 011 | [外形 availability test を Azure Monitor SLI の正本にする](011-external-availability-sli-publisher.md) | Superseded | 2026-05-19 |
 | 012 | [Azure Functions direct probe を Azure Monitor SLI の正本にする](012-functions-direct-external-sli-probe.md) | Accepted (Latency 部分は ADR-014 で amend) | 2026-05-20 |
-| 013 | [uv workspace でツーリングを統一しつつデプロイ単位は分離維持](013-uv-workspace-unified-tooling.md) | Accepted | 2026-05-21 |
+| 013 | [uv workspace でツーリングを統一しつつデプロイ単位は分離維持](013-uv-workspace-unified-tooling.md) | Accepted (root lock 一本化、Docker uv sync、post-edit hook 自動 sync 許可の該当部分は ADR-017 で amend) | 2026-05-21 |
 | 014 | [Latency SLI を `le` bucket と `eq` filter で定義する](014-histogram-bucket-latency-sli.md) | Accepted | 2026-05-21 |
 | 015 | [Azure リソース名への resourceToken サフィックス付与ルール](015-resource-token-suffix-naming.md) | Accepted | 2026-06-28 |
 | 016 | [Azure Chaos Studio Workspace の採用](016-azure-chaos-studio-workspace-adoption.md) | Rejected | 2026-07-16 |
+| 017 | [管理対象環境向け approved-index 変換フロー (ADR-013 の一部を amend)](017-approved-index-conversion-for-managed-environments.md) | Accepted | 2026-08-08 |

--- a/docs/chaos-experiments.md
+++ b/docs/chaos-experiments.md
@@ -33,7 +33,7 @@ az rest --method post \
 
 ## 観察の進め方
 
-1. `uv run scripts/tasks.py load-baseline` で負荷をかける。
+1. `uv run --no-project "${PWD}/scripts/tasks.py" load-baseline` で負荷をかける。
 2. 別ターミナルで Chaos 実験を開始する。
 3. [observability.md](observability.md) の `gateway:chaos_app:*`、Application Insights、Container Insights、Container network logs を確認する。
 4. 実験停止後、回復時間と SLI / operational alerts の反応を確認する。

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -143,59 +143,120 @@ azd env set AZURE_AKS_NODE_VM_SIZE Standard_D4pds_v6 -e eval
 
 ## ローカル開発
 
-リポジトリは uv workspace 構成です。ルートで一度同期すれば、`src/api` と `src/external-sli-publisher` の両方の依存と開発ツール (ruff / ty / pytest / locust) が揃います。
+リポジトリは uv workspace 構成です。uv は host、CI、Docker で `0.12.2` に固定しています。ルートで一度同期すれば、`src/api` と `src/external-sli-publisher` の両方の依存と開発ツール (ruff / ty / pytest / locust) が揃います。
 
 ```bash
-uv run scripts/tasks.py sync-dev
+uv run --no-project "${PWD}/scripts/tasks.py" check-uv-version
+uv run --no-project "${PWD}/scripts/tasks.py" sync-dev
 lefthook install
-uv run scripts/tasks.py run
+uv run --no-project "${PWD}/scripts/tasks.py" run
 ```
 
 `lefthook install` は、コントリビュータ向けにこのリポジトリの Git hooks を登録します。ステージされた `infra/` 配下の Bicep ファイルがある場合、pre-commit は `infra/main.bicep` をビルドし、失敗したコミットを中止します。Lefthook のインストール方法は [公式手順](https://lefthook.dev/install/) を参照してください。
+
+### 組織承認済み package index を使う環境
+
+public package registry へ直接接続できない環境では、user-level の uv 設定に組織承認済みの Python package index を一つ構成します。`[[index]]`には`default = true`を指定し、public PyPIへのfallbackを無効にします。index URLや認証情報はリポジトリへ保存しません。
+
+```bash
+uv run --no-project "${PWD}/scripts/tasks.py" sync-dev-approved-index
+uv run --no-project "${PWD}/scripts/tasks.py" qa-app
+```
+
+このタスクはuser-level設定とpublic lockのsourceを検査してから、public `uv.lock`を一時requirementsへ変換し、構成済みのpackage indexから`.venv`を作成します。変換後のrequirementsも検査し、direct URL、find-links、hash検証やTLS検証を無効にする設定、projectやdependency groupを変更する環境変数を拒否します。exportと後続の`uv run`はroot projectと対象venvの絶対pathへ固定します。registry packageには`--require-hashes`を適用し、workspace sourceはindexを介さず`.pth`で参照します。通常環境と分離した`.uv-state/cache/`を使い、一時requirementsは処理後に削除します。`.uv-state/`配下のstateは同期した`uv.lock`のSHA-256を記録し、後続のtaskは検証済み環境へ`--no-sync`を適用します。stateを`.venv`の外へ置くため、環境の再作成が中断しても未完了状態が残ります。
+
+post-edit hookは依存関係の整合性を判定しません。Python編集時はprojectの`.venv`にある`ruff`を直接実行し、ruffがない場合は同期を要求します。lockと仮想環境の整合性は同期taskとCIで検証します。
+
+`uv.lock`が変わった場合や同期が中断した場合、taskは古い環境を使わず再同期を要求します。同じコマンドを再実行してください。通常の同期へ戻す場合は`.venv`を削除し、`uv run --no-project "${PWD}/scripts/tasks.py" reset-approved-index-state`を実行してから`sync-dev`を実行します。
+
+task runnerを介さない `uv run` では、projectの自動同期を明示的に止めます。
+
+```bash
+UV_NO_SYNC=1 uv run <command>
+```
+
+PowerShellでは `$env:UV_NO_SYNC = "1"` を設定します。
+
+### Docker build のpackage index
+
+通常のDocker buildはpublic PyPIを使用します。
+
+```bash
+docker build -f src/api/Dockerfile -t aks-chaos-lab:local .
+```
+
+組織承認済みpackage indexが必要な管理対象環境では、ローカルbuildに限りuser-level `uv.toml` をBuildKit secretとして渡します。このsecretを公開CIへ渡してはいけません。
+
+```bash
+UV_CONFIG_PATH="$HOME/.config/uv/uv.toml"
+UV_INDEX_CONFIG_SHA256="$(
+  uv run --no-project "${PWD}/scripts/approved_index_config.py" digest "$UV_CONFIG_PATH"
+)"
+docker build \
+  --build-arg UV_INDEX_MODE=approved-index \
+  --build-arg UV_INDEX_CONFIG_SHA256="$UV_INDEX_CONFIG_SHA256" \
+  --secret id=uv-config,src="$UV_CONFIG_PATH" \
+  -f src/api/Dockerfile \
+  -t aks-chaos-lab:local .
+```
+
+configのSHA-256はdependency layerとcache mountのkeyになります。Dockerfileはmountしたconfigのhashを照合するため、configを変更すると古いlayerを再利用しません。build logを共有する前に、index URLや認証情報が含まれていないことを確認してください。
+
+### public lockfile の更新
+
+dependencyを変更する場合、public PyPIへ接続できるGitHub Actionsでlockfileを生成します。workflowはrepositoryへのwrite permissionを持たず、`uv.lock` をartifactとして返します。
+
+```bash
+gh workflow run refresh-uv-lock.yml --ref <branch>
+gh run list --workflow refresh-uv-lock.yml
+gh run download <run-id> --name uv-lock-public
+```
+
+取得した`uv.lock`の差分を確認して変更branchへ追加した後、組織承認済みpackage indexを使う環境で`sync-dev-approved-index`を再実行します。package indexがpublic lockと同一hashのartifactを提供できない場合、同期は失敗します。
 
 ## テストと品質確認
 
 アプリケーション:
 
-クリーン環境や新しい worktree では、先に `uv run scripts/tasks.py sync-dev` を実行してください。`qa-app` は同期済みの workspace venv を前提に ruff、ty、pytest を実行します。
+クリーン環境や新しいworktreeでは、先に通常環境で`uv run --no-project "${PWD}/scripts/tasks.py" sync-dev`、組織承認済みpackage indexを使う環境で`uv run --no-project "${PWD}/scripts/tasks.py" sync-dev-approved-index`を実行してください。絶対pathと`--no-project`は、task runnerの起動前にuvが別のprojectを探索または同期することを防ぎます。`qa-app`は同期済みのworkspace venvを前提にruff、ty、pytestを実行します。
 
 ```bash
-uv run scripts/tasks.py test
-uv run scripts/tasks.py test-cov
-uv run scripts/tasks.py lint
-uv run scripts/tasks.py typecheck
-uv run scripts/tasks.py qa-app
+uv run --no-project "${PWD}/scripts/tasks.py" test
+uv run --no-project "${PWD}/scripts/tasks.py" test-cov
+uv run --no-project "${PWD}/scripts/tasks.py" lint
+uv run --no-project "${PWD}/scripts/tasks.py" typecheck
+uv run --no-project "${PWD}/scripts/tasks.py" qa-app
 ```
 
 Bicep:
 
 ```bash
-uv run scripts/tasks.py build-bicep
+uv run --no-project "${PWD}/scripts/tasks.py" build-bicep
 ```
 
 Git hooks:
 
 ```bash
-uv run scripts/tasks.py test-hooks
+uv run --no-project "${PWD}/scripts/tasks.py" test-hooks
 ```
 
 リポジトリ全体:
 
 ```bash
-uv run scripts/tasks.py qa
+uv run --no-project "${PWD}/scripts/tasks.py" qa
 ```
 
-`uv run scripts/tasks.py qa` は workflows、Bicep、Kubernetes manifests、アプリ、リポジトリ用 Python scripts の QA をまとめて実行します。必要な外部ツールの確認は `uv run scripts/tasks.py install-tools` / `check-*` ターゲットで実行できます。
+`uv run --no-project "${PWD}/scripts/tasks.py" qa`はworkflows、Bicep、Kubernetes manifests、アプリ、リポジトリ用Python scriptsのQAをまとめて実行します。必要な外部ツールの確認は`uv run --no-project "${PWD}/scripts/tasks.py" install-tools`と`check-*`ターゲットで実行できます。
 
 ## 負荷テスト
 
 Locust ベースの負荷を生成できます。`BASE_URL` 未指定時は `AZURE_INGRESS_FQDN` を優先し、未設定の場合は Gateway から自動検出します。
 
 ```bash
-uv run scripts/tasks.py load-smoke
-uv run scripts/tasks.py load-baseline
-uv run scripts/tasks.py load-stress
-uv run scripts/tasks.py load-spike
+uv run --no-project "${PWD}/scripts/tasks.py" load-smoke
+uv run --no-project "${PWD}/scripts/tasks.py" load-baseline
+uv run --no-project "${PWD}/scripts/tasks.py" load-stress
+uv run --no-project "${PWD}/scripts/tasks.py" load-spike
 ```
 
 手動で対象 URL や負荷パラメーターを指定する場合は、利用中のシェルで環境変数を設定してから同じタスクを実行します。
@@ -205,7 +266,7 @@ $env:BASE_URL = "http://<host-or-ip>"
 $env:USERS = "100"
 $env:SPAWN_RATE = "10"
 $env:DURATION = "300"
-uv run scripts/tasks.py load-baseline
+uv run --no-project "${PWD}/scripts/tasks.py" load-baseline
 ```
 
 ```bash
@@ -213,10 +274,10 @@ export BASE_URL=http://<host-or-ip>
 export USERS=100
 export SPAWN_RATE=10
 export DURATION=300
-uv run scripts/tasks.py load-baseline
+uv run --no-project "${PWD}/scripts/tasks.py" load-baseline
 ```
 
-Chaos 実験の観察時は、別ターミナルで `uv run scripts/tasks.py load-baseline` を継続しながら [docs/chaos-experiments.md](chaos-experiments.md) の実験を開始すると挙動を追いやすくなります。
+Chaos実験の観察時は、別ターミナルで`uv run --no-project "${PWD}/scripts/tasks.py" load-baseline`を継続しながら[docs/chaos-experiments.md](chaos-experiments.md)の実験を開始すると挙動を追いやすくなります。
 
 ## 既存環境の SLI 信号移行 cleanup
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -207,12 +207,11 @@ configのSHA-256はdependency layerとcache mountのkeyになります。Dockerf
 dependencyを変更する場合、public PyPIへ接続できるGitHub Actionsでlockfileを生成します。workflowはrepositoryへのwrite permissionを持たず、`uv.lock` をartifactとして返します。
 
 ```bash
-gh workflow run refresh-uv-lock.yml --ref <branch>
-gh run list --workflow refresh-uv-lock.yml
-gh run download <run-id> --name uv-lock-public
+gh run list --workflow refresh-uv-lock.yml --branch <branch>
+gh run download <run-id> --name uv-lock-public --dir tmp/refresh-uv-lock
 ```
 
-取得した`uv.lock`の差分を確認して変更branchへ追加した後、組織承認済みpackage indexを使う環境で`sync-dev-approved-index`を再実行します。package indexがpublic lockと同一hashのartifactを提供できない場合、同期は失敗します。
+workflowは`pyproject.toml`、`uv.lock`、workflow定義自身を変更したpull requestで実行されます。既定branchへmergeした後は`workflow_dispatch`でも実行できます。取得した`uv.lock`の差分を確認して変更branchへ追加した後、組織承認済みpackage indexを使う環境で`sync-dev-approved-index`を再実行します。package indexがpublic lockと同一hashのartifactを提供できない場合、同期は失敗します。
 
 ## テストと品質確認
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -2,4 +2,4 @@ pre-commit:
   commands:
     bicep-build:
       glob: "{infra/*.bicep,infra/**/*.bicep}"
-      run: uv run scripts/tasks.py build-bicep
+      run: uv run --no-project "${PWD}/scripts/tasks.py" build-bicep

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dev = [
 ]
 
 [tool.uv]
-required-version = ">=0.10.6"
+required-version = "==0.12.2"
 package = false
 
 [tool.uv.workspace]

--- a/scripts/approved_index_config.py
+++ b/scripts/approved_index_config.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import hashlib
+import os
+import sys
+import tomllib
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from urllib.parse import urlparse
+
+PUBLIC_PACKAGE_HOSTS = frozenset(("files.pythonhosted.org", "pypi.org"))
+UNSAFE_UV_ENVIRONMENT_VARIABLES = frozenset(
+    (
+        "UV_ALL_EXTRAS",
+        "UV_ALL_GROUPS",
+        "UV_BUILD_CONSTRAINT",
+        "UV_CONSTRAINT",
+        "UV_DEFAULT_INDEX",
+        "UV_DEFAULT_GROUPS",
+        "UV_DEV",
+        "UV_EXTRA_INDEX_URL",
+        "UV_EXTRA",
+        "UV_FIND_LINKS",
+        "UV_GROUP",
+        "UV_INDEX",
+        "UV_INDEX_STRATEGY",
+        "UV_INDEX_URL",
+        "UV_INSECURE_HOST",
+        "UV_ISOLATED",
+        "UV_NO_ALL_EXTRAS",
+        "UV_NO_CONFIG",
+        "UV_NO_DEV",
+        "UV_NO_EXTRA",
+        "UV_NO_GROUP",
+        "UV_NO_INDEX",
+        "UV_NO_PROJECT",
+        "UV_NO_SOURCES",
+        "UV_NO_VERIFY_HASHES",
+        "UV_ONLY_GROUP",
+        "UV_OVERRIDE",
+        "UV_PACKAGE",
+        "UV_PROJECT",
+        "UV_WORKING_DIR",
+    )
+)
+LEGACY_INDEX_KEYS = frozenset(
+    (
+        "default-index",
+        "allow-insecure-host",
+        "extra-index-url",
+        "find-links",
+        "index-url",
+        "index-strategy",
+        "insecure-host",
+        "no-index",
+        "no-verify-hashes",
+    )
+)
+
+
+class ApprovedIndexConfigError(ValueError):
+    pass
+
+
+def user_uv_config_path(environ: Mapping[str, str] = os.environ) -> Path:
+    configured = environ.get("UV_CONFIG_FILE")
+    if configured:
+        return Path(configured).expanduser().resolve()
+
+    xdg_config_home = environ.get("XDG_CONFIG_HOME")
+    if xdg_config_home:
+        return Path(xdg_config_home).expanduser().resolve() / "uv" / "uv.toml"
+
+    if os.name == "nt":
+        app_data = environ.get("APPDATA")
+        if not app_data:
+            raise ApprovedIndexConfigError(
+                "APPDATA is not set, so the user-level uv configuration cannot be located."
+            )
+        return Path(app_data).expanduser().resolve() / "uv" / "uv.toml"
+
+    return Path.home() / ".config" / "uv" / "uv.toml"
+
+
+def validate_approved_index_config(
+    config_path: Path,
+    environ: Mapping[str, str] = os.environ,
+) -> None:
+    overrides = sorted(
+        name for name in UNSAFE_UV_ENVIRONMENT_VARIABLES if environ.get(name)
+    )
+    if overrides:
+        raise ApprovedIndexConfigError(
+            "Unsafe uv environment overrides are not allowed: " + ", ".join(overrides)
+        )
+
+    try:
+        config = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    except FileNotFoundError as error:
+        raise ApprovedIndexConfigError(
+            "The user-level uv configuration was not found."
+        ) from error
+    except (OSError, tomllib.TOMLDecodeError) as error:
+        raise ApprovedIndexConfigError(
+            f"The user-level uv configuration is invalid: {error}"
+        ) from error
+
+    conflicting_keys = sorted(LEGACY_INDEX_KEYS.intersection(config))
+    if conflicting_keys:
+        raise ApprovedIndexConfigError(
+            "Unsupported uv source or verification settings are present: "
+            + ", ".join(conflicting_keys)
+        )
+    if "pip" in config:
+        raise ApprovedIndexConfigError(
+            "A [pip] table is not allowed in the approved-index uv configuration."
+        )
+
+    indexes = config.get("index")
+    if not isinstance(indexes, list) or len(indexes) != 1:
+        raise ApprovedIndexConfigError(
+            "The user-level uv configuration must contain exactly one [[index]] entry."
+        )
+
+    index = indexes[0]
+    if not isinstance(index, dict):
+        raise ApprovedIndexConfigError("The [[index]] entry must be a TOML table.")
+    if not isinstance(index.get("name"), str) or not index["name"].strip():
+        raise ApprovedIndexConfigError(
+            "The [[index]] entry must have a non-empty name."
+        )
+    if index.get("default") is not True:
+        raise ApprovedIndexConfigError(
+            "The configured [[index]] must set default = true to disable public fallback."
+        )
+
+    url = index.get("url")
+    if not isinstance(url, str):
+        raise ApprovedIndexConfigError("The configured [[index]] must have a URL.")
+    parsed = urlparse(url)
+    if (
+        parsed.scheme != "https"
+        or not parsed.hostname
+        or parsed.username is not None
+        or parsed.password is not None
+        or parsed.query
+        or parsed.fragment
+    ):
+        raise ApprovedIndexConfigError(
+            "The configured [[index]] URL must be an HTTPS URL without "
+            "credentials, a query, or a fragment."
+        )
+    if parsed.hostname.rstrip(".").lower() in PUBLIC_PACKAGE_HOSTS:
+        raise ApprovedIndexConfigError(
+            "The configured [[index]] must not resolve directly to a public package host."
+        )
+
+
+def config_sha256(config_path: Path) -> str:
+    digest = hashlib.sha256()
+    with config_path.open("rb") as config_file:
+        for chunk in iter(lambda: config_file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def main(argv: Sequence[str]) -> int:
+    digest_requested = len(argv) == 2 and argv[0] == "digest"
+    if len(argv) != 1 and not digest_requested:
+        print(
+            "Usage: approved_index_config.py [digest] <uv-config-path>",
+            file=sys.stderr,
+        )
+        return 2
+    config_path = Path(argv[-1])
+    try:
+        validate_approved_index_config(config_path)
+    except ApprovedIndexConfigError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+    if digest_requested:
+        print(config_sha256(config_path))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/public_lock.py
+++ b/scripts/public_lock.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import re
+import sys
+import tomllib
+from collections.abc import Sequence
+from pathlib import Path
+from urllib.parse import urlparse
+
+PUBLIC_ARTIFACT_HOST = "files.pythonhosted.org"
+PUBLIC_PYPI_INDEX = "https://pypi.org/simple"
+HASH_OPTION = re.compile(r"^--hash=sha256:[0-9a-f]{64}$")
+PINNED_REQUIREMENT = re.compile(r"^[A-Za-z0-9_.\-\[\],]+==[^\s;]+(?:\s*;\s*.+)?$")
+
+
+class PublicLockError(ValueError):
+    pass
+
+
+def workspace_members(pyproject_path: Path) -> set[str]:
+    project = tomllib.loads(pyproject_path.read_text(encoding="utf-8"))
+    return set(project["tool"]["uv"]["workspace"]["members"])
+
+
+def validate_artifact_url(url: object) -> None:
+    if not isinstance(url, str):
+        raise PublicLockError("uv.lock contains a non-string artifact URL.")
+    parsed = urlparse(url)
+    try:
+        valid = (
+            parsed.scheme == "https"
+            and parsed.hostname == PUBLIC_ARTIFACT_HOST
+            and parsed.port is None
+            and parsed.username is None
+            and parsed.password is None
+        )
+    except ValueError:
+        valid = False
+    if not valid:
+        raise PublicLockError("uv.lock contains an artifact URL outside public PyPI.")
+
+
+def validate_public_lock(pyproject_path: Path, lock_path: Path) -> None:
+    lock = tomllib.loads(lock_path.read_text(encoding="utf-8"))
+    allowed_workspace_sources = workspace_members(pyproject_path) | {"."}
+    registry_packages = 0
+    for package in lock.get("package", []):
+        source = package.get("source", {})
+        if not isinstance(source, dict):
+            source = {}
+        if source == {"registry": PUBLIC_PYPI_INDEX}:
+            registry_packages += 1
+        elif (
+            len(source) == 1
+            and next(iter(source), None) in {"editable", "virtual"}
+            and next(iter(source.values()), None) in allowed_workspace_sources
+        ):
+            pass
+        else:
+            raise PublicLockError(
+                f"uv.lock package {package.get('name', '<unknown>')} "
+                "has an unsupported source type."
+            )
+
+        sdist = package.get("sdist")
+        if isinstance(sdist, dict) and "url" in sdist:
+            validate_artifact_url(sdist["url"])
+        for wheel in package.get("wheels", []):
+            if isinstance(wheel, dict) and "url" in wheel:
+                validate_artifact_url(wheel["url"])
+
+    if registry_packages == 0:
+        raise PublicLockError("uv.lock does not contain public PyPI registry packages.")
+
+
+def validate_exported_requirements(
+    requirements_path: Path,
+) -> None:
+    pending_requirement_line: int | None = None
+    pending_requirement_has_hash = False
+
+    def finish_pending_requirement() -> None:
+        if pending_requirement_line is not None and not pending_requirement_has_hash:
+            raise PublicLockError(
+                f"Exported requirements line {pending_requirement_line} "
+                "does not have a SHA-256 hash."
+            )
+
+    for line_number, raw_line in enumerate(
+        requirements_path.read_text(encoding="utf-8").splitlines(),
+        start=1,
+    ):
+        line = raw_line.strip().removesuffix("\\").rstrip()
+        if not line or line.startswith("#"):
+            continue
+        if HASH_OPTION.fullmatch(line):
+            if pending_requirement_line is None:
+                raise PublicLockError(
+                    f"Exported requirements line {line_number} has an orphaned hash."
+                )
+            pending_requirement_has_hash = True
+            continue
+        finish_pending_requirement()
+        pending_requirement_line = None
+        pending_requirement_has_hash = False
+        if any(
+            token in line.lower()
+            for token in (" @ ", "://", "file:", "git+", "--find-links")
+        ):
+            raise PublicLockError(
+                f"Exported requirements line {line_number} contains a direct source."
+            )
+        if PINNED_REQUIREMENT.fullmatch(line):
+            pending_requirement_line = line_number
+            continue
+        raise PublicLockError(
+            f"Exported requirements line {line_number} is not a hash-pinned "
+            "registry requirement."
+        )
+    finish_pending_requirement()
+
+
+def main(argv: Sequence[str]) -> int:
+    try:
+        if len(argv) == 3 and argv[0] == "lock":
+            validate_public_lock(Path(argv[1]), Path(argv[2]))
+        elif len(argv) == 2 and argv[0] == "requirements":
+            validate_exported_requirements(Path(argv[1]))
+        else:
+            print(
+                "Usage: public_lock.py "
+                "(lock <pyproject> <uv.lock> | requirements <requirements>)",
+                file=sys.stderr,
+            )
+            return 2
+    except (OSError, PublicLockError, tomllib.TOMLDecodeError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -5,14 +5,30 @@
 # ///
 from __future__ import annotations
 
+import hashlib
+import json
 import os
 import re
 import shutil
 import subprocess
 import sys
+import tempfile
 import tomllib
 from collections.abc import Callable, Sequence
+from contextlib import suppress
 from pathlib import Path
+
+from approved_index_config import (
+    UNSAFE_UV_ENVIRONMENT_VARIABLES,
+    ApprovedIndexConfigError,
+    user_uv_config_path,
+    validate_approved_index_config,
+)
+from public_lock import (
+    PublicLockError,
+    validate_exported_requirements,
+    validate_public_lock,
+)
 
 ROOT = Path(__file__).resolve().parents[1]
 SRC = ROOT / "src"
@@ -22,6 +38,9 @@ ACTIONLINT_IMAGE = "rhysd/actionlint:1.7.12"
 KUBECONFORM_IMAGE = "ghcr.io/yannh/kubeconform:v0.7.0"
 K8S_VERSION = "1.33.0"
 KUBECONFORM_SKIP = "VerticalPodAutoscaler,CiliumNetworkPolicy,Kustomization,Gateway,HTTPRoute,Instrumentation"
+APPROVED_INDEX_STATE_DIRECTORY = ".uv-state"
+APPROVED_INDEX_ENVIRONMENT_STATE_FILENAME = ".approved-index-sync.json"
+APPROVED_INDEX_STATE_VERSION = 3
 
 
 def print_step(message: str) -> None:
@@ -49,10 +68,158 @@ def resolve_command(args: Sequence[str]) -> list[str]:
 def child_env(extra: dict[str, str] | None = None) -> dict[str, str]:
     env = os.environ.copy()
     env.pop("VIRTUAL_ENV", None)
+    for name in UNSAFE_UV_ENVIRONMENT_VARIABLES:
+        env.pop(name, None)
     env.setdefault("PYTHONUTF8", "1")
     if extra:
         env.update(extra)
     return env
+
+
+def project_environment_path() -> Path:
+    configured = os.environ.get("UV_PROJECT_ENVIRONMENT")
+    if not configured:
+        return ROOT / ".venv"
+    path = Path(configured).expanduser()
+    return path if path.is_absolute() else ROOT / path
+
+
+def approved_index_state_path() -> Path:
+    environment = str(project_environment_path().resolve())
+    environment_key = hashlib.sha256(environment.encode()).hexdigest()[:16]
+    return (
+        ROOT / APPROVED_INDEX_STATE_DIRECTORY / f"approved-index-{environment_key}.json"
+    )
+
+
+def approved_index_cache_path() -> Path:
+    return ROOT / APPROVED_INDEX_STATE_DIRECTORY / "cache"
+
+
+def approved_index_environment_state_path() -> Path:
+    return project_environment_path() / APPROVED_INDEX_ENVIRONMENT_STATE_FILENAME
+
+
+def lock_sha256() -> str:
+    digest = hashlib.sha256()
+    with (ROOT / "uv.lock").open("rb") as lock_file:
+        for chunk in iter(lambda: lock_file.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def write_approved_index_state(status: str, lock_digest: str | None = None) -> None:
+    state = {
+        "schema": APPROVED_INDEX_STATE_VERSION,
+        "status": status,
+        "lock_sha256": lock_digest or lock_sha256(),
+    }
+
+    def write_state(state_path: Path) -> None:
+        state_path.parent.mkdir(parents=True, exist_ok=True)
+        temporary_path = state_path.with_suffix(".tmp")
+        temporary_path.write_text(
+            json.dumps(state, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        temporary_path.replace(state_path)
+
+    if status == "ready":
+        write_state(approved_index_environment_state_path())
+    state_path = approved_index_state_path()
+    write_state(state_path)
+
+
+def read_approved_index_state() -> dict[str, object] | None:
+    state_path = approved_index_state_path()
+    if not state_path.exists():
+        return None
+    try:
+        state = json.loads(state_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as error:
+        print(f"error: Invalid approved-index sync state: {error}", file=sys.stderr)
+        raise SystemExit(1) from error
+    if not isinstance(state, dict):
+        print("error: Invalid approved-index sync state format", file=sys.stderr)
+        raise SystemExit(1)
+    return state
+
+
+def approved_index_run_flags() -> list[str]:
+    state = read_approved_index_state()
+    if state is None:
+        return []
+    if (
+        state.get("schema") != APPROVED_INDEX_STATE_VERSION
+        or state.get("status") != "ready"
+    ):
+        print(
+            "error: The approved-index environment is incomplete. "
+            'Run \'uv run --no-project "${PWD}/scripts/tasks.py" '
+            "sync-dev-approved-index'.",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+    if state.get("lock_sha256") != lock_sha256():
+        print(
+            "error: uv.lock changed after the approved-index environment was synced. "
+            'Run \'uv run --no-project "${PWD}/scripts/tasks.py" '
+            "sync-dev-approved-index'.",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+    environment_state_path = approved_index_environment_state_path()
+    try:
+        environment_state = json.loads(
+            environment_state_path.read_text(encoding="utf-8")
+        )
+    except (OSError, json.JSONDecodeError) as error:
+        print(
+            f"error: Invalid approved-index environment provenance: {error}",
+            file=sys.stderr,
+        )
+        raise SystemExit(1) from error
+    if environment_state != state:
+        print(
+            "error: The virtual environment does not match its approved-index state. "
+            'Run \'uv run --no-project "${PWD}/scripts/tasks.py" '
+            "sync-dev-approved-index'.",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+    return ["--no-sync"]
+
+
+def ensure_standard_sync_allowed() -> None:
+    if approved_index_state_path().exists():
+        print(
+            "error: This environment is managed by the approved-index workflow. "
+            'Run \'uv run --no-project "${PWD}/scripts/tasks.py" '
+            "sync-dev-approved-index' "
+            "to refresh it. To return to standard sync, remove the virtual environment "
+            "and run the reset-approved-index-state target.",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
+
+def environment_python_path() -> Path:
+    environment = project_environment_path()
+    if os.name == "nt":
+        return environment / "Scripts" / "python.exe"
+    return environment / "bin" / "python"
+
+
+def environment_site_packages_path() -> Path:
+    environment = project_environment_path()
+    if os.name == "nt":
+        return environment / "Lib" / "site-packages"
+    return (
+        environment
+        / "lib"
+        / f"python{sys.version_info.major}.{sys.version_info.minor}"
+        / "site-packages"
+    )
 
 
 def run(
@@ -65,7 +232,7 @@ def run(
     completed = subprocess.run(
         resolve_command(args),
         cwd=cwd,
-        env=env if env is not None else child_env(),
+        env=child_env(env),
         check=False,
     )
     if check and completed.returncode != 0:
@@ -98,7 +265,22 @@ def command_output(
 
 def run_uv(args: Sequence[str], *, env: dict[str, str] | None = None) -> None:
     """Run a command in the workspace venv from the repository root."""
-    run(["uv", "run", *args], cwd=ROOT, env=env)
+    project_env = {
+        "UV_PROJECT_ENVIRONMENT": str(project_environment_path()),
+        **(env or {}),
+    }
+    run(
+        [
+            "uv",
+            "run",
+            "--project",
+            str(ROOT),
+            *approved_index_run_flags(),
+            *args,
+        ],
+        cwd=ROOT,
+        env=project_env,
+    )
 
 
 def run_uv_in(
@@ -112,12 +294,27 @@ def run_uv_in(
     Used for pytest invocations that rely on the subpackage's pytest config and
     PYTHONPATH layout (e.g. `tests/` discovering `app/` via cwd-based imports).
     """
-    run(["uv", "run", *args], cwd=cwd, env=env)
+    project_env = {
+        "UV_PROJECT_ENVIRONMENT": str(project_environment_path()),
+        **(env or {}),
+    }
+    run(
+        [
+            "uv",
+            "run",
+            "--project",
+            str(ROOT),
+            *approved_index_run_flags(),
+            *args,
+        ],
+        cwd=cwd,
+        env=project_env,
+    )
 
 
 def pythonpath_env(extra: dict[str, str] | None = None) -> dict[str, str]:
-    env = child_env(extra)
-    existing = env.get("PYTHONPATH")
+    env = dict(extra or {})
+    existing = os.environ.get("PYTHONPATH")
     env["PYTHONPATH"] = f".{os.pathsep}{existing}" if existing else "."
     return env
 
@@ -127,7 +324,7 @@ def docker_mount(path: Path, target: str) -> str:
 
 
 def target_help() -> None:
-    print("Usage: uv run scripts/tasks.py <target>")
+    print('Usage: uv run --no-project "${PWD}/scripts/tasks.py" <target>')
     print()
     print("Targets:")
     for name in sorted(TARGETS):
@@ -135,21 +332,120 @@ def target_help() -> None:
 
 
 def target_install() -> None:
+    ensure_standard_sync_allowed()
     print_step("Installing workspace development dependencies")
-    run(["uv", "sync", "--all-packages", "--all-groups"])
+    run(["uv", "sync", "--project", str(ROOT), "--all-packages", "--all-groups"])
     print_success("Dependencies installed")
 
 
 def target_sync() -> None:
+    ensure_standard_sync_allowed()
     print_step("Syncing workspace dependencies (runtime only)")
-    run(["uv", "sync", "--all-packages"])
+    run(["uv", "sync", "--project", str(ROOT), "--all-packages"])
     print_success("Dependencies synced")
 
 
 def target_sync_dev() -> None:
+    ensure_standard_sync_allowed()
     print_step("Syncing workspace development dependencies")
-    run(["uv", "sync", "--all-packages", "--all-groups"])
+    run(["uv", "sync", "--project", str(ROOT), "--all-packages", "--all-groups"])
     print_success("Development dependencies synced")
+
+
+def target_sync_dev_approved_index() -> None:
+    print_step("Syncing workspace dependencies from the approved package index")
+    environment = project_environment_path()
+    config_path = user_uv_config_path()
+    try:
+        validate_approved_index_config(config_path)
+    except ApprovedIndexConfigError as error:
+        print(f"error: {error}", file=sys.stderr)
+        raise SystemExit(1) from error
+    lock_digest = lock_sha256()
+    try:
+        validate_public_lock(ROOT / "pyproject.toml", ROOT / "uv.lock")
+    except (OSError, PublicLockError, tomllib.TOMLDecodeError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        raise SystemExit(1) from error
+    write_approved_index_state("in-progress", lock_digest)
+    with tempfile.TemporaryDirectory(prefix="aks-chaos-lab-uv-") as temporary_dir:
+        requirements = Path(temporary_dir) / "requirements.txt"
+        run(
+            [
+                "uv",
+                "venv",
+                "--clear",
+                "--python",
+                "3.14",
+                str(environment),
+            ]
+        )
+        run(
+            [
+                "uv",
+                "export",
+                "--project",
+                str(ROOT),
+                "--quiet",
+                "--frozen",
+                "--all-packages",
+                "--all-groups",
+                "--no-emit-workspace",
+                "--no-emit-index-url",
+                "--output-file",
+                str(requirements),
+            ]
+        )
+        try:
+            validate_exported_requirements(requirements)
+        except (OSError, PublicLockError) as error:
+            print(f"error: {error}", file=sys.stderr)
+            raise SystemExit(1) from error
+        run(
+            [
+                "uv",
+                "pip",
+                "sync",
+                "--require-hashes",
+                str(requirements),
+                "--python",
+                str(environment_python_path()),
+            ],
+            env={
+                "UV_CACHE_DIR": str(approved_index_cache_path()),
+                "UV_CONFIG_FILE": str(config_path),
+            },
+        )
+        site_packages = environment_site_packages_path()
+        site_packages.mkdir(parents=True, exist_ok=True)
+        (site_packages / "aks-chaos-lab-workspace.pth").write_text(
+            f"{API_DIR.resolve()}\n{PUBLISHER_DIR.resolve()}\n",
+            encoding="utf-8",
+        )
+    if lock_sha256() != lock_digest:
+        print(
+            "error: uv.lock changed while the approved-index environment was syncing. "
+            "Run the sync target again.",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+    write_approved_index_state("ready", lock_digest)
+    print_success("Approved-index development dependencies synced")
+
+
+def target_reset_approved_index_state() -> None:
+    environment = project_environment_path()
+    if environment.exists():
+        print(
+            f"error: Remove the virtual environment first: {environment}",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+    state_path = approved_index_state_path()
+    state_path.unlink(missing_ok=True)
+    with suppress(OSError):
+        state_path.parent.rmdir()
+    print_success("Approved-index state reset")
 
 
 # ---------------------------------------------------------------------------
@@ -209,7 +505,7 @@ def target_test_publisher() -> None:
 def target_test_hooks() -> None:
     print_step("Testing repository hooks")
     target_check_lefthook()
-    run_uv(["pytest", "scripts/tests/test_lefthook.py", "-q"])
+    run_uv(["pytest", "scripts/tests/", "-q"])
     print_success("Repository hook tests passed")
 
 
@@ -412,9 +708,18 @@ def target_install_tools() -> None:
 
 
 def target_check_uv_version() -> None:
-    root_pyproject = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
-    expected_match = re.search(r'required-version\s*=\s*">=([^"]+)"', root_pyproject)
-    expected = expected_match.group(1) if expected_match else "not set"
+    root_pyproject = tomllib.loads(
+        (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    )
+    required_version = root_pyproject["tool"]["uv"].get("required-version", "")
+    expected_match = re.fullmatch(r"==([0-9]+\.[0-9]+\.[0-9]+)", required_version)
+    if expected_match is None:
+        print(
+            "error: [tool.uv].required-version must use an exact ==X.Y.Z version",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+    expected = expected_match.group(1)
 
     local_version_output = command_output(
         ["uv", "--version"], allow_failure=True, quiet_stderr=True
@@ -441,12 +746,22 @@ def target_check_uv_version() -> None:
         raise SystemExit(1)
 
     if local_version != expected:
-        print(f"warning: Local uv ({local_version}) differs from expected ({expected})")
         print(
-            "  Patch version differences within the same minor version are compatible"
+            f"error: Local uv ({local_version}) differs from expected ({expected})",
+            file=sys.stderr,
         )
-    else:
-        print_success("All uv versions match")
+        raise SystemExit(1)
+    print_success("All uv versions match")
+
+
+def target_check_public_lock() -> None:
+    print_step("Checking public uv.lock package sources")
+    try:
+        validate_public_lock(ROOT / "pyproject.toml", ROOT / "uv.lock")
+    except (OSError, PublicLockError, tomllib.TOMLDecodeError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        raise SystemExit(1) from error
+    print_success("uv.lock contains only public PyPI package sources")
 
 
 def normalized_dependency(value: str) -> str:
@@ -678,6 +993,7 @@ TARGETS: dict[str, Callable[[], None]] = {
     "check-gh-aw": target_check_gh_aw,
     "check-lefthook": target_check_lefthook,
     "check-publisher-requirements": target_check_publisher_requirements,
+    "check-public-lock": target_check_public_lock,
     "check-uv-version": target_check_uv_version,
     "clean": target_clean,
     "compile-aw": target_compile_aw,
@@ -699,9 +1015,11 @@ TARGETS: dict[str, Callable[[], None]] = {
     "qa-platform": target_qa_platform,
     "qa-scripts": target_qa_scripts,
     "qa-workflows": target_qa_workflows,
+    "reset-approved-index-state": target_reset_approved_index_state,
     "run": target_run,
     "sync": target_sync,
     "sync-dev": target_sync_dev,
+    "sync-dev-approved-index": target_sync_dev_approved_index,
     "test": target_test,
     "test-all": target_test_all,
     "test-api": target_test_api,
@@ -728,7 +1046,9 @@ def main(argv: Sequence[str]) -> int:
     if handler is None:
         print(f"error: Unknown target: {target}", file=sys.stderr)
         print(
-            "Run 'uv run scripts/tasks.py help' for available targets.", file=sys.stderr
+            "Run 'uv run --no-project \"${PWD}/scripts/tasks.py\" help' "
+            "for available targets.",
+            file=sys.stderr,
         )
         return 1
 

--- a/scripts/tests/test_lefthook.py
+++ b/scripts/tests/test_lefthook.py
@@ -76,7 +76,9 @@ def test_bicep_pre_commit_selection(
     calls = (
         log_path.read_text(encoding="utf-8").splitlines() if log_path.exists() else []
     )
-    expected = ["run scripts/tasks.py build-bicep"] if should_run else []
+    expected = (
+        [f"run --no-project {ROOT}/scripts/tasks.py build-bicep"] if should_run else []
+    )
     assert calls == expected
 
 
@@ -144,5 +146,5 @@ def test_bicep_pre_commit_uses_staged_files(tmp_path: Path) -> None:
     )
     assert staged_result.returncode == 0, staged_result.stderr
     assert log_path.read_text(encoding="utf-8").splitlines() == [
-        "run scripts/tasks.py build-bicep"
+        f"run --no-project {repository}/scripts/tasks.py build-bicep"
     ]

--- a/scripts/tests/test_uv_workflow.py
+++ b/scripts/tests/test_uv_workflow.py
@@ -1,0 +1,427 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def load_module(name: str, path: Path) -> ModuleType:
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Unable to load {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+approved_config = load_module(
+    "approved_index_config",
+    REPO_ROOT / "scripts" / "approved_index_config.py",
+)
+public_lock = load_module(
+    "public_lock",
+    REPO_ROOT / "scripts" / "public_lock.py",
+)
+tasks = load_module("repository_tasks", REPO_ROOT / "scripts" / "tasks.py")
+post_edit = load_module(
+    "post_edit_quality_feedback",
+    REPO_ROOT / ".github" / "hooks" / "scripts" / "post-edit-quality-feedback.py",
+)
+
+
+def configure_root(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, lock_content: str = "version = 1\n"
+) -> None:
+    (tmp_path / "uv.lock").write_text(lock_content, encoding="utf-8")
+    monkeypatch.setattr(tasks, "ROOT", tmp_path)
+    monkeypatch.setattr(post_edit, "REPO_ROOT", tmp_path)
+    monkeypatch.delenv("UV_PROJECT_ENVIRONMENT", raising=False)
+
+
+def write_approved_config(
+    path: Path, url: str = "https://packages.example.test/simple"
+) -> None:
+    path.write_text(
+        f'[[index]]\nname = "approved-index"\nurl = "{url}"\ndefault = true\n',
+        encoding="utf-8",
+    )
+
+
+def test_ready_state_adds_no_sync(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    configure_root(monkeypatch, tmp_path)
+    (tmp_path / ".venv").mkdir()
+
+    tasks.write_approved_index_state("ready")
+
+    assert tasks.approved_index_run_flags() == ["--no-sync"]
+
+
+def test_changed_lock_fails_closed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    configure_root(monkeypatch, tmp_path)
+    (tmp_path / ".venv").mkdir()
+    tasks.write_approved_index_state("ready")
+    (tmp_path / "uv.lock").write_text("version = 2\n", encoding="utf-8")
+
+    with pytest.raises(SystemExit):
+        tasks.approved_index_run_flags()
+
+
+def test_missing_environment_provenance_fails_closed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    configure_root(monkeypatch, tmp_path)
+    (tmp_path / ".venv").mkdir()
+    tasks.write_approved_index_state("ready")
+    tasks.approved_index_environment_state_path().unlink()
+
+    with pytest.raises(SystemExit):
+        tasks.approved_index_run_flags()
+
+
+def test_incomplete_state_fails_closed(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    configure_root(monkeypatch, tmp_path)
+    state_path = tasks.approved_index_state_path()
+    state_path.parent.mkdir()
+    state_path.write_text(
+        json.dumps(
+            {
+                "schema": tasks.APPROVED_INDEX_STATE_VERSION,
+                "status": "in-progress",
+                "lock_sha256": tasks.lock_sha256(),
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit):
+        tasks.approved_index_run_flags()
+
+
+def test_project_environment_honors_relative_override(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    configure_root(monkeypatch, tmp_path)
+    monkeypatch.setenv("UV_PROJECT_ENVIRONMENT", "build/venv")
+
+    assert tasks.project_environment_path() == tmp_path / "build" / "venv"
+
+
+def test_state_is_stored_outside_virtual_environment(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    configure_root(monkeypatch, tmp_path)
+
+    state_path = tasks.approved_index_state_path()
+
+    assert state_path.parent == tmp_path / tasks.APPROVED_INDEX_STATE_DIRECTORY
+    assert tmp_path / ".venv" not in state_path.parents
+
+
+def test_approved_index_config_requires_one_non_public_default(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "uv.toml"
+    write_approved_config(config_path)
+
+    approved_config.validate_approved_index_config(config_path, {})
+
+    write_approved_config(config_path, "https://pypi.org/simple")
+    with pytest.raises(approved_config.ApprovedIndexConfigError):
+        approved_config.validate_approved_index_config(config_path, {})
+
+    write_approved_config(config_path, "https://pypi.org./simple")
+    with pytest.raises(approved_config.ApprovedIndexConfigError):
+        approved_config.validate_approved_index_config(config_path, {})
+
+
+def test_approved_index_config_rejects_source_environment_override(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "uv.toml"
+    write_approved_config(config_path)
+
+    with pytest.raises(approved_config.ApprovedIndexConfigError):
+        approved_config.validate_approved_index_config(
+            config_path,
+            {"UV_DEFAULT_INDEX": "https://packages.example.test/simple"},
+        )
+
+    with pytest.raises(approved_config.ApprovedIndexConfigError):
+        approved_config.validate_approved_index_config(
+            config_path,
+            {"UV_FIND_LINKS": "https://packages.example.test/wheels"},
+        )
+    for variable in (
+        "UV_BUILD_CONSTRAINT",
+        "UV_INSECURE_HOST",
+        "UV_NO_CONFIG",
+        "UV_NO_DEV",
+        "UV_NO_VERIFY_HASHES",
+        "UV_PROJECT",
+        "UV_WORKING_DIR",
+    ):
+        with pytest.raises(approved_config.ApprovedIndexConfigError):
+            approved_config.validate_approved_index_config(
+                config_path,
+                {variable: "1"},
+            )
+
+
+def test_child_environment_removes_unsafe_uv_overrides(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("UV_PROJECT", "/not-a-project")
+    monkeypatch.setenv("UV_NO_DEV", "1")
+    monkeypatch.setenv("UV_INDEX_APPROVED_INDEX_USERNAME", "username")
+
+    environment = tasks.child_env()
+
+    assert "UV_PROJECT" not in environment
+    assert "UV_NO_DEV" not in environment
+    assert environment["UV_INDEX_APPROVED_INDEX_USERNAME"] == "username"
+
+
+def test_run_uv_binds_root_project_and_environment(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    configure_root(monkeypatch, tmp_path)
+    calls: list[tuple[list[str], dict[str, str]]] = []
+
+    def capture_run(
+        args: list[str],
+        *,
+        env: dict[str, str],
+        **_kwargs: object,
+    ) -> None:
+        calls.append((args, env))
+
+    monkeypatch.setattr(tasks, "run", capture_run)
+
+    tasks.run_uv(["ruff", "check"])
+
+    assert calls == [
+        (
+            [
+                "uv",
+                "run",
+                "--project",
+                str(tmp_path),
+                "ruff",
+                "check",
+            ],
+            {"UV_PROJECT_ENVIRONMENT": str(tmp_path / ".venv")},
+        )
+    ]
+
+
+def test_post_edit_invokes_project_ruff_directly(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    configure_root(monkeypatch, tmp_path)
+    ruff = tmp_path / ".venv" / "bin" / "ruff"
+    ruff.parent.mkdir(parents=True)
+    ruff.touch()
+    source_path = tmp_path / "example.py"
+    source_path.write_text("value = 1\n", encoding="utf-8")
+    commands: list[list[str]] = []
+
+    def capture_command(
+        command: list[str],
+        **_kwargs: object,
+    ) -> object:
+        commands.append(command)
+        return post_edit.CommandResult(command, 0, "", "")
+
+    monkeypatch.setattr(post_edit, "run_command", capture_command)
+
+    post_edit.process_python(source_path)
+
+    assert len(commands) == 2
+    assert commands == [
+        [str(ruff), "check", "--fix", "--quiet", str(source_path)],
+        [str(ruff), "format", "--quiet", str(source_path)],
+    ]
+
+
+def test_post_edit_reports_missing_project_ruff(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    configure_root(monkeypatch, tmp_path)
+    source_path = tmp_path / "example.py"
+    source_path.write_text("value = 1\n", encoding="utf-8")
+
+    messages = post_edit.process_python(source_path)
+
+    assert messages == [
+        "The project virtual environment does not contain ruff. Run the "
+        "appropriate sync target before editing Python files."
+    ]
+
+
+def test_approved_index_config_rejects_find_links_setting(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "uv.toml"
+    config_path.write_text(
+        'find-links = ["https://packages.example.test/wheels"]\n'
+        '[[index]]\nname = "approved-index"\n'
+        'url = "https://packages.example.test/simple"\ndefault = true\n',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(approved_config.ApprovedIndexConfigError):
+        approved_config.validate_approved_index_config(config_path, {})
+
+
+def test_approved_index_config_rejects_pip_table(tmp_path: Path) -> None:
+    config_path = tmp_path / "uv.toml"
+    config_path.write_text(
+        "[pip]\nverify-hashes = false\n"
+        '[[index]]\nname = "approved-index"\n'
+        'url = "https://packages.example.test/simple"\ndefault = true\n',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(approved_config.ApprovedIndexConfigError):
+        approved_config.validate_approved_index_config(config_path, {})
+
+
+def test_lock_change_during_sync_keeps_in_progress_state(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    configure_root(monkeypatch, tmp_path)
+    config_path = tmp_path / "uv.toml"
+    write_approved_config(config_path)
+    monkeypatch.setattr(tasks, "user_uv_config_path", lambda: config_path)
+    monkeypatch.setattr(tasks, "validate_public_lock", lambda *_args: None)
+    monkeypatch.setattr(
+        tasks,
+        "validate_exported_requirements",
+        lambda *_args: None,
+    )
+    pip_environment: dict[str, str] = {}
+
+    def change_lock_after_install(args: list[str], **kwargs: object) -> None:
+        if args[:3] == ["uv", "pip", "sync"]:
+            env = kwargs.get("env")
+            assert isinstance(env, dict)
+            pip_environment.update(
+                {str(name): str(value) for name, value in env.items()}
+            )
+            (tmp_path / "uv.lock").write_text("version = 2\n", encoding="utf-8")
+
+    monkeypatch.setattr(tasks, "run", change_lock_after_install)
+
+    with pytest.raises(SystemExit):
+        tasks.target_sync_dev_approved_index()
+
+    state = json.loads(tasks.approved_index_state_path().read_text(encoding="utf-8"))
+    assert state["status"] == "in-progress"
+    assert pip_environment == {
+        "UV_CACHE_DIR": str(tasks.approved_index_cache_path()),
+        "UV_CONFIG_FILE": str(config_path),
+    }
+
+
+def test_environment_creation_failure_keeps_in_progress_state(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    configure_root(monkeypatch, tmp_path)
+    config_path = tmp_path / "uv.toml"
+    write_approved_config(config_path)
+    monkeypatch.setattr(tasks, "user_uv_config_path", lambda: config_path)
+    monkeypatch.setattr(tasks, "validate_public_lock", lambda *_args: None)
+
+    def fail_environment_creation(_args: list[str], **_kwargs: object) -> None:
+        raise RuntimeError("simulated interruption")
+
+    monkeypatch.setattr(tasks, "run", fail_environment_creation)
+
+    with pytest.raises(RuntimeError, match="simulated interruption"):
+        tasks.target_sync_dev_approved_index()
+
+    state = json.loads(tasks.approved_index_state_path().read_text(encoding="utf-8"))
+    assert state["status"] == "in-progress"
+
+
+def test_public_lock_rejects_direct_url_source(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    configure_root(
+        monkeypatch,
+        tmp_path,
+        (
+            "version = 1\n"
+            '[[package]]\nname = "unsafe"\nversion = "1.0.0"\n'
+            'source = { url = "https://example.test/unsafe.whl" }\n'
+        ),
+    )
+    (tmp_path / "pyproject.toml").write_text(
+        "[tool.uv.workspace]\nmembers = []\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit):
+        tasks.target_check_public_lock()
+
+
+def test_exported_requirements_reject_direct_source(tmp_path: Path) -> None:
+    requirements_path = tmp_path / "requirements.txt"
+    requirements_path.write_text(
+        "unsafe @ https://example.test/unsafe.whl\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(public_lock.PublicLockError):
+        public_lock.validate_exported_requirements(requirements_path)
+
+
+def test_exported_requirements_require_sha256_hash(tmp_path: Path) -> None:
+    requirements_path = tmp_path / "requirements.txt"
+    requirements_path.write_text("safe==1.0.0\n", encoding="utf-8")
+
+    with pytest.raises(public_lock.PublicLockError):
+        public_lock.validate_exported_requirements(requirements_path)
+
+    requirements_path.write_text(
+        f"safe==1.0.0 \\\n    --hash=sha256:{'0' * 64}\n",
+        encoding="utf-8",
+    )
+    public_lock.validate_exported_requirements(requirements_path)
+
+
+def test_check_uv_version_requires_exact_match(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    configure_root(monkeypatch, tmp_path)
+    (tmp_path / "pyproject.toml").write_text(
+        '[tool.uv]\nrequired-version = "==0.12.2"\n',
+        encoding="utf-8",
+    )
+    api_dir = tmp_path / "src" / "api"
+    api_dir.mkdir(parents=True)
+    (api_dir / "Dockerfile").write_text(
+        "FROM ghcr.io/astral-sh/uv:0.12.2 AS uv\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(tasks, "API_DIR", api_dir)
+    monkeypatch.setattr(tasks, "command_output", lambda *args, **kwargs: "uv 0.12.2")
+
+    tasks.target_check_uv_version()
+
+    monkeypatch.setattr(tasks, "command_output", lambda *args, **kwargs: "uv 0.12.3")
+    with pytest.raises(SystemExit):
+        tasks.target_check_uv_version()

--- a/src/api/Dockerfile
+++ b/src/api/Dockerfile
@@ -1,10 +1,10 @@
 # uv version pinned - keep in sync with the root pyproject.toml [tool.uv] required-version
-# Run 'uv run scripts/tasks.py check-uv-version' from the repository root to verify consistency
+# Run 'uv run --no-project scripts/tasks.py check-uv-version' to verify consistency
 #
 # Build context MUST be the repository root because the workspace lockfile lives at the
 # repository root. Build with:
 #   docker build -f src/api/Dockerfile -t aks-chaos-lab:local .
-FROM ghcr.io/astral-sh/uv:0.10.6 AS uv
+FROM ghcr.io/astral-sh/uv:0.12.2 AS uv
 
 FROM python:3.14-slim
 
@@ -19,13 +19,37 @@ WORKDIR /app
 COPY pyproject.toml uv.lock ./
 COPY src/api/pyproject.toml ./src/api/
 COPY src/external-sli-publisher/pyproject.toml ./src/external-sli-publisher/
+COPY scripts/approved_index_config.py ./scripts/
+COPY scripts/public_lock.py ./scripts/
 
-# Install only the API package's locked dependencies (no dev, no project install).
-# --package selects the workspace member; --no-install-project skips installing
-# aks-chaos-lab-api itself so that we can copy the source tree later.
+# Export only the API package's locked dependencies, then resolve the artifacts
+# through the package index configured for this build environment.
 ENV UV_LINK_MODE=copy
-RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --package aks-chaos-lab-api --no-install-project --no-dev --compile-bytecode
+ARG UV_INDEX_MODE=public
+ARG UV_INDEX_CONFIG_SHA256=public
+RUN --mount=type=cache,id=uv-${UV_INDEX_MODE}-${UV_INDEX_CONFIG_SHA256},target=/root/.cache/uv \
+    --mount=type=secret,id=uv-config,target=/root/.config/uv/uv.toml,required=false \
+    case "$UV_INDEX_MODE" in \
+      public) \
+        test "$UV_INDEX_CONFIG_SHA256" = public \
+        && test ! -e /root/.config/uv/uv.toml \
+        ;; \
+      approved-index) \
+        printf '%s  %s\n' "$UV_INDEX_CONFIG_SHA256" /root/.config/uv/uv.toml \
+          | sha256sum -c - \
+        && python scripts/approved_index_config.py /root/.config/uv/uv.toml \
+        ;; \
+      *) echo "error: UV_INDEX_MODE must be public or approved-index" >&2; exit 1 ;; \
+    esac \
+    && python scripts/public_lock.py lock pyproject.toml uv.lock \
+    && uv export --quiet --frozen --package aks-chaos-lab-api --no-dev \
+      --no-emit-workspace --no-emit-index-url \
+      --output-file /tmp/requirements.txt \
+    && python scripts/public_lock.py requirements /tmp/requirements.txt \
+    && uv venv /app/.venv \
+    && uv pip sync --require-hashes /tmp/requirements.txt \
+      --python /app/.venv/bin/python --compile-bytecode \
+    && rm /tmp/requirements.txt
 
 # Copy application code
 COPY src/api/app ./app

--- a/src/api/tests/load/README.md
+++ b/src/api/tests/load/README.md
@@ -14,29 +14,29 @@
 ### 基本的な使用（自動検出）
 ```bash
 # BASE_URLを自動検出してbaseline負荷テスト実行
-uv run scripts/tasks.py load-baseline
+uv run --no-project "${PWD}/scripts/tasks.py" load-baseline
 
 # smoke（軽量・既定のクイック検証）
-uv run scripts/tasks.py load-smoke
+uv run --no-project "${PWD}/scripts/tasks.py" load-smoke
 
 # stress負荷テスト実行
-uv run scripts/tasks.py load-stress
+uv run --no-project "${PWD}/scripts/tasks.py" load-stress
 
 # spike負荷テスト実行
-uv run scripts/tasks.py load-spike
+uv run --no-project "${PWD}/scripts/tasks.py" load-spike
 ```
 
 ### 手動でBASE_URL指定
 ```bash
 export BASE_URL=https://myapp.example.com
-uv run scripts/tasks.py load-baseline
+uv run --no-project "${PWD}/scripts/tasks.py" load-baseline
 ```
 
 PowerShell:
 
 ```powershell
 $env:BASE_URL = "https://myapp.example.com"
-uv run scripts/tasks.py load-baseline
+uv run --no-project "${PWD}/scripts/tasks.py" load-baseline
 ```
 
 ### カスタム設定
@@ -44,13 +44,13 @@ uv run scripts/tasks.py load-baseline
 # 異なるGatewayを対象にする場合
 export GATEWAY_NAME=my-gateway
 export GATEWAY_NS=my-namespace
-uv run scripts/tasks.py load-baseline
+uv run --no-project "${PWD}/scripts/tasks.py" load-baseline
 
 # 負荷パラメータをカスタマイズ
 export USERS=100
 export SPAWN_RATE=10
 export DURATION=300
-uv run scripts/tasks.py load-baseline
+uv run --no-project "${PWD}/scripts/tasks.py" load-baseline
 ```
 
 ## 負荷プロファイル
@@ -79,13 +79,13 @@ uv run scripts/tasks.py load-baseline
 
 ### 初回実行前の準備
 ```bash
-uv run scripts/tasks.py sync-dev
+uv run --no-project "${PWD}/scripts/tasks.py" sync-dev
 ```
 
 ### 依存関係について
 - locustはsrc/api/pyproject.tomlのdev dependenciesで定義
 - uvが自動的に仮想環境を管理  
-- `uv run scripts/tasks.py load-*` は `src/api/` の dev dependencies を使って Locust を実行
+- `uv run --no-project "${PWD}/scripts/tasks.py" load-*` は `src/api/` の dev dependencies を使って Locust を実行
 
 ## 前提条件
 - kubectl がインストール済みでクラスタにアクセス可能
@@ -102,7 +102,7 @@ BASE_URL が未設定の場合、以下の優先順で自動検出します：
 例：
 ```bash
 # BASE_URL 自動検出で baseline を実行
-uv run scripts/tasks.py load-baseline
+uv run --no-project "${PWD}/scripts/tasks.py" load-baseline
 ```
 
 2) Kubernetes Gateway からの検出


### PR DESCRIPTION
## 背景

会社管理端末ではpublic package repositoryへの直接アクセスが制限されます。一方、GitHub Actionsと社外利用者が組織専用indexへ依存しないよう、repositoryの`uv.lock`はpublic PyPIを正本として維持する必要があります。

## 変更内容

- public lockを`uv export --frozen`でhash付きrequirementsへ変換し、user-levelで構成した組織承認済みindexから環境を構築します。
- managed環境ではindex設定、lock source、state、venv provenance、cacheを検証し、異なるsource由来の環境をfail closedで拒否します。
- Docker buildではBuildKit secretでindex設定を渡し、設定値をimageへ残さず、config digestでdependency cacheを分離します。
- host、CI、Dockerのuvを0.12.2へ統一します。
- public PyPI環境でlockを生成するread-only GitHub Actions workflowと、設計判断、利用手順、回帰テストを追加します。
- post-edit hookはproject `.venv`のruffを直接実行するだけに限定し、依存関係の整合性検査は同期taskとCIへ集約します。

## レビュー時の注意点

managed環境のstateはvenv外とvenv内の2箇所に保存します。外部stateは中断された再構築を検出し、venv内markerは対象環境がapproved-index経路で作られたことを証明します。