### PR TITLE
fix: allow compatible uv patch releases on developer hosts

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,7 +10,7 @@ AKS 上の Chaos Engineering ラボ環境。azd でインフラとアプリを�
 - **IaC**: Bicep, subscription scope (`infra/`)
 - **K8s**: Kustomize (`k8s/`)
 - **依存**: Redis (Managed, Entra ID auth), Application Insights, Prometheus
-- **パッケージ管理**: uv 0.12.2 の workspace (ルート `pyproject.toml` + public PyPI source の `uv.lock`、`python`/`pip` 直接実行禁止)
+- **パッケージ管理**: uv workspace (hostはルート`pyproject.toml`の互換範囲、CIとDockerはその下限に固定、ルート `pyproject.toml` + public PyPI source の `uv.lock`、`python`/`pip` 直接実行禁止)
 - **品質検証**: ruff + ty + pytest → クリーン環境では通常は `uv run --no-project "${PWD}/scripts/tasks.py" sync-dev`、組織承認済み package index を必須とする環境では `uv run --no-project "${PWD}/scripts/tasks.py" sync-dev-approved-index` の後に `uv run --no-project "${PWD}/scripts/tasks.py" qa-app`
 - **Bicep 検証**: `uv run --no-project "${PWD}/scripts/tasks.py" build-bicep`。Lefthook の pre-commit は、ステージされた Bicep 変更がある場合に実行する
 - **編集時自動検証**: `.github/hooks/hooks.json` に postToolUse hook を登録。`.py` 編集では project `.venv` の ruff を直接実行し、`.bicep` 編集では `az bicep format` を実行する。変更/失敗時はエージェントへ `additionalContext` でフィードバックする。依存関係の整合性は同期taskとCIが検証する

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
-          version-file: "pyproject.toml"
+          version: "0.12.2"
           python-version: "3.14"
       - name: Check lock consistency
         run: uv lock --check
@@ -34,7 +34,7 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
-          version-file: "pyproject.toml"
+          version: "0.12.2"
           python-version: "3.14"
       - name: Sync deps (dev)
         run: uv run --no-project "${{ github.workspace }}/scripts/tasks.py" sync-dev
@@ -49,7 +49,7 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
-          version-file: "pyproject.toml"
+          version: "0.12.2"
           python-version: "3.14"
       - name: Sync deps (dev)
         run: uv run --no-project "${{ github.workspace }}/scripts/tasks.py" sync-dev
@@ -65,7 +65,7 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
-          version-file: "pyproject.toml"
+          version: "0.12.2"
           python-version: "3.14"
       - name: Sync deps (dev)
         run: uv run --no-project "${{ github.workspace }}/scripts/tasks.py" sync-dev
@@ -80,7 +80,7 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
-          version-file: "pyproject.toml"
+          version: "0.12.2"
           python-version: "3.14"
       - name: Sync deps (dev)
         run: uv run --no-project "${{ github.workspace }}/scripts/tasks.py" sync-dev

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -197,7 +197,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
-          version-file: "pyproject.toml"
+          version: "0.12.2"
 
       - name: Smoke test - Health endpoint
         env:

--- a/.github/workflows/refresh-uv-lock.yml
+++ b/.github/workflows/refresh-uv-lock.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
-          version-file: "pyproject.toml"
+          version: "0.12.2"
           python-version: "3.14"
       - name: Refresh lock
         run: uv lock

--- a/docs/adr/017-approved-index-conversion-for-managed-environments.md
+++ b/docs/adr/017-approved-index-conversion-for-managed-environments.md
@@ -14,7 +14,7 @@ Public GitHub repository では public PyPI source の root `uv.lock` を唯一�
 5. task runnerはscriptの絶対pathと`uv run --no-project`で起動し、taskのstate検査より前に別のprojectを探索または同期しないようにする。
 6. GitHub Actions、Azure Functions remote build、外部利用者はpublic PyPIを継続して使用する。
 7. Docker buildも同じexportとpip syncを使う。管理対象環境のローカルbuildはbuild argumentでapproved-index modeとconfigのSHA-256を明示し、BuildKit secretでuser-level uv configをmountする。Dockerfileはmountしたconfigのhashを照合し、build modeとhashをdependency layerおよびBuildKit cache mountのkeyへ含める。公開CIにはsecretを渡さない。
-8. uvはhost、CI、Dockerのすべてで`0.12.2`にexact pinする。
+8. uvのhostはルート`pyproject.toml`で定義する単一minor seriesの互換範囲を許可する。CI、Docker、lock更新workflowは互換範囲の下限へexact pinし、再現性を維持する。
 9. dependency update時のpublic lockはGitHub Actionsのread-only artifact workflowで生成し、botのcommit permissionまたはwrite permissionを使わない。
 10. ADR-013のroot lock一本化、Dockerのuv sync、post-edit hookの自動sync許可を上記方式へamendする。post-edit hookは依存関係の整合性を判定せず、project venvのruffを直接実行する。uv workspaceによる統一とADR-009/012のdeploy単位分離は維持する。
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -143,7 +143,7 @@ azd env set AZURE_AKS_NODE_VM_SIZE Standard_D4pds_v6 -e eval
 
 ## ローカル開発
 
-リポジトリは uv workspace 構成です。uv は host、CI、Docker で `0.12.2` に固定しています。ルートで一度同期すれば、`src/api` と `src/external-sli-publisher` の両方の依存と開発ツール (ruff / ty / pytest / locust) が揃います。
+リポジトリは uv workspace 構成です。hostはルート`pyproject.toml`の互換範囲に従います。CI、Docker、lock更新workflowは、再現性を維持するため互換範囲の下限へ固定します。`check-uv-version`はこの関係を検査します。ルートで一度同期すれば、`src/api` と `src/external-sli-publisher` の両方の依存と開発ツール (ruff / ty / pytest / locust) が揃います。
 
 ```bash
 uv run --no-project "${PWD}/scripts/tasks.py" check-uv-version

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dev = [
 ]
 
 [tool.uv]
-required-version = "==0.12.2"
+required-version = ">=0.12.2,<0.13.0"
 package = false
 
 [tool.uv.workspace]

--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -34,6 +34,7 @@ ROOT = Path(__file__).resolve().parents[1]
 SRC = ROOT / "src"
 API_DIR = SRC / "api"
 PUBLISHER_DIR = SRC / "external-sli-publisher"
+WORKFLOWS_DIR = ROOT / ".github" / "workflows"
 ACTIONLINT_IMAGE = "rhysd/actionlint:1.7.12"
 KUBECONFORM_IMAGE = "ghcr.io/yannh/kubeconform:v0.7.0"
 K8S_VERSION = "1.33.0"
@@ -712,14 +713,27 @@ def target_check_uv_version() -> None:
         (ROOT / "pyproject.toml").read_text(encoding="utf-8")
     )
     required_version = root_pyproject["tool"]["uv"].get("required-version", "")
-    expected_match = re.fullmatch(r"==([0-9]+\.[0-9]+\.[0-9]+)", required_version)
-    if expected_match is None:
+    required_match = re.fullmatch(
+        r">=([0-9]+\.[0-9]+\.[0-9]+),<([0-9]+\.[0-9]+\.[0-9]+)",
+        required_version,
+    )
+    if required_match is None:
         print(
-            "error: [tool.uv].required-version must use an exact ==X.Y.Z version",
+            "error: [tool.uv].required-version must use "
+            "a >=X.Y.Z,<X.Y.Z compatibility range",
             file=sys.stderr,
         )
         raise SystemExit(1)
-    expected = expected_match.group(1)
+    minimum_text, upper_bound_text = required_match.groups()
+    minimum = tuple(int(part) for part in minimum_text.split("."))
+    upper_bound = tuple(int(part) for part in upper_bound_text.split("."))
+    expected_upper_bound = (minimum[0], minimum[1] + 1, 0)
+    if upper_bound != expected_upper_bound:
+        print(
+            "error: [tool.uv].required-version must allow one uv minor series",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
 
     local_version_output = command_output(
         ["uv", "--version"], allow_failure=True, quiet_stderr=True
@@ -730,28 +744,92 @@ def target_check_uv_version() -> None:
 
     dockerfile = (API_DIR / "Dockerfile").read_text(encoding="utf-8")
     docker_match = re.search(
-        r"ghcr\.io/astral-sh/uv:([0-9]+\.[0-9]+\.[0-9]+)", dockerfile
+        r"^FROM\s+ghcr\.io/astral-sh/uv:"
+        r"([0-9]+\.[0-9]+\.[0-9]+)\s+AS\s+uv\s*$",
+        dockerfile,
+        flags=re.IGNORECASE | re.MULTILINE,
     )
     docker_version = docker_match.group(1) if docker_match else "not found"
 
-    print(f"  Expected workspace uv:  {expected}")
+    workflow_versions: list[tuple[Path, str]] = []
+    workflow_paths = sorted(
+        (*WORKFLOWS_DIR.glob("*.yml"), *WORKFLOWS_DIR.glob("*.yaml"))
+    )
+    for workflow_path in workflow_paths:
+        lines = workflow_path.read_text(encoding="utf-8").splitlines()
+        for index, line in enumerate(lines):
+            if "uses: astral-sh/setup-uv@" not in line:
+                continue
+            action_indent = len(line) - len(line.lstrip())
+            pinned_version = "not pinned"
+            with_indent: int | None = None
+            with_child_indent: int | None = None
+            for candidate in lines[index + 1 :]:
+                stripped_candidate = candidate.strip()
+                if not stripped_candidate:
+                    continue
+                candidate_indent = len(candidate) - len(candidate.lstrip())
+                if candidate_indent <= action_indent and candidate.lstrip().startswith(
+                    "- "
+                ):
+                    break
+                if with_indent is None:
+                    if stripped_candidate == "with:":
+                        with_indent = candidate_indent
+                    continue
+                if candidate_indent <= with_indent:
+                    break
+                if with_child_indent is None:
+                    with_child_indent = candidate_indent
+                if candidate_indent != with_child_indent:
+                    continue
+                version_match = re.fullmatch(
+                    r"""version:\s*["']?([0-9]+\.[0-9]+\.[0-9]+)["']?""",
+                    stripped_candidate,
+                )
+                if version_match is not None:
+                    pinned_version = version_match.group(1)
+                    break
+            workflow_versions.append((workflow_path, pinned_version))
+
+    print(f"  Required workspace uv:  {required_version}")
     print(f"  Local uv:               {local_version}")
-    print(f"  Docker uv:              {docker_version}")
+    print(f"  Pinned Docker uv:       {docker_version}")
+    print(f"  Pinned workflow uv:     {minimum_text}")
 
-    if docker_version != expected:
+    if docker_version != minimum_text:
         print(
-            "error: Docker uv version mismatch with root pyproject.toml",
+            f"error: Docker uv ({docker_version}) must remain pinned to "
+            f"the minimum workspace version ({minimum_text})",
             file=sys.stderr,
         )
         raise SystemExit(1)
 
-    if local_version != expected:
+    for workflow_path, workflow_version in workflow_versions:
+        if workflow_version != minimum_text:
+            print(
+                f"error: {workflow_path.relative_to(ROOT)} setup-uv "
+                f"({workflow_version}) must remain pinned to "
+                f"the minimum workspace version ({minimum_text})",
+                file=sys.stderr,
+            )
+            raise SystemExit(1)
+
+    local_match = re.fullmatch(r"[0-9]+\.[0-9]+\.[0-9]+", local_version)
+    if local_match is None:
         print(
-            f"error: Local uv ({local_version}) differs from expected ({expected})",
+            f"error: Local uv version is unavailable or invalid ({local_version})",
             file=sys.stderr,
         )
         raise SystemExit(1)
-    print_success("All uv versions match")
+    local = tuple(int(part) for part in local_version.split("."))
+    if not minimum <= local < upper_bound:
+        print(
+            f"error: Local uv ({local_version}) does not satisfy {required_version}",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+    print_success("Local uv is compatible and reproducible environments remain pinned")
 
 
 def target_check_public_lock() -> None:

--- a/scripts/tests/test_uv_workflow.py
+++ b/scripts/tests/test_uv_workflow.py
@@ -403,12 +403,12 @@ def test_exported_requirements_require_sha256_hash(tmp_path: Path) -> None:
     public_lock.validate_exported_requirements(requirements_path)
 
 
-def test_check_uv_version_requires_exact_match(
+def test_check_uv_version_allows_compatible_host_patch(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     configure_root(monkeypatch, tmp_path)
     (tmp_path / "pyproject.toml").write_text(
-        '[tool.uv]\nrequired-version = "==0.12.2"\n',
+        '[tool.uv]\nrequired-version = ">=0.12.2,<0.13.0"\n',
         encoding="utf-8",
     )
     api_dir = tmp_path / "src" / "api"
@@ -417,11 +417,116 @@ def test_check_uv_version_requires_exact_match(
         "FROM ghcr.io/astral-sh/uv:0.12.2 AS uv\n",
         encoding="utf-8",
     )
+    workflow_path = tmp_path / ".github" / "workflows" / "ci.yml"
+    workflow_path.parent.mkdir(parents=True)
+    workflow_path.write_text(
+        "steps:\n"
+        "  - uses: astral-sh/setup-uv@sha\n"
+        "    with:\n"
+        '      version: "0.12.2"\n',
+        encoding="utf-8",
+    )
     monkeypatch.setattr(tasks, "API_DIR", api_dir)
+    monkeypatch.setattr(tasks, "WORKFLOWS_DIR", workflow_path.parent)
     monkeypatch.setattr(tasks, "command_output", lambda *args, **kwargs: "uv 0.12.2")
 
     tasks.target_check_uv_version()
 
     monkeypatch.setattr(tasks, "command_output", lambda *args, **kwargs: "uv 0.12.3")
+    tasks.target_check_uv_version()
+
+    monkeypatch.setattr(tasks, "command_output", lambda *args, **kwargs: "uv 0.13.0")
+    with pytest.raises(SystemExit):
+        tasks.target_check_uv_version()
+
+    monkeypatch.setattr(tasks, "command_output", lambda *args, **kwargs: "uv 0.12.1")
+    with pytest.raises(SystemExit):
+        tasks.target_check_uv_version()
+
+
+def test_check_uv_version_requires_pinned_docker_version(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    configure_root(monkeypatch, tmp_path)
+    (tmp_path / "pyproject.toml").write_text(
+        '[tool.uv]\nrequired-version = ">=0.12.2,<0.13.0"\n',
+        encoding="utf-8",
+    )
+    api_dir = tmp_path / "src" / "api"
+    api_dir.mkdir(parents=True)
+    (api_dir / "Dockerfile").write_text(
+        "# old image: ghcr.io/astral-sh/uv:0.12.2\n"
+        "FROM ghcr.io/astral-sh/uv:0.12.3 AS uv\n",
+        encoding="utf-8",
+    )
+    workflow_path = tmp_path / ".github" / "workflows" / "ci.yml"
+    workflow_path.parent.mkdir(parents=True)
+    workflow_path.write_text(
+        "steps:\n"
+        "  - uses: astral-sh/setup-uv@sha\n"
+        "    with:\n"
+        '      version: "0.12.2"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(tasks, "API_DIR", api_dir)
+    monkeypatch.setattr(tasks, "WORKFLOWS_DIR", workflow_path.parent)
+    monkeypatch.setattr(tasks, "command_output", lambda *args, **kwargs: "uv 0.12.3")
+
+    with pytest.raises(SystemExit):
+        tasks.target_check_uv_version()
+
+
+def test_check_uv_version_requires_pinned_workflow_version(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    configure_root(monkeypatch, tmp_path)
+    (tmp_path / "pyproject.toml").write_text(
+        '[tool.uv]\nrequired-version = ">=0.12.2,<0.13.0"\n',
+        encoding="utf-8",
+    )
+    api_dir = tmp_path / "src" / "api"
+    api_dir.mkdir(parents=True)
+    (api_dir / "Dockerfile").write_text(
+        "FROM ghcr.io/astral-sh/uv:0.12.2 AS uv\n",
+        encoding="utf-8",
+    )
+    workflow_path = tmp_path / ".github" / "workflows" / "ci.yml"
+    workflow_path.parent.mkdir(parents=True)
+    workflow_path.write_text(
+        "steps:\n"
+        "  - uses: astral-sh/setup-uv@sha\n"
+        "    with:\n"
+        '      version: "0.12.3"\n',
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(tasks, "API_DIR", api_dir)
+    monkeypatch.setattr(tasks, "WORKFLOWS_DIR", workflow_path.parent)
+    monkeypatch.setattr(tasks, "command_output", lambda *args, **kwargs: "uv 0.12.3")
+
+    with pytest.raises(SystemExit):
+        tasks.target_check_uv_version()
+
+    workflow_path.write_text(
+        "steps:\n"
+        "  - uses: astral-sh/setup-uv@sha\n"
+        "    env:\n"
+        '      version: "0.12.2"\n'
+        "    with:\n"
+        '      version-file: "pyproject.toml"\n',
+        encoding="utf-8",
+    )
+    with pytest.raises(SystemExit):
+        tasks.target_check_uv_version()
+
+
+def test_check_uv_version_requires_one_minor_compatibility_range(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    configure_root(monkeypatch, tmp_path)
+    (tmp_path / "pyproject.toml").write_text(
+        '[tool.uv]\nrequired-version = "==0.12.2"\n',
+        encoding="utf-8",
+    )
+
     with pytest.raises(SystemExit):
         tasks.target_check_uv_version()

--- a/src/api/Dockerfile
+++ b/src/api/Dockerfile
@@ -1,5 +1,6 @@
-# uv version pinned - keep in sync with the root pyproject.toml [tool.uv] required-version
-# Run 'uv run --no-project scripts/tasks.py check-uv-version' to verify consistency
+# uv is pinned for reproducible builds and must equal the minimum version allowed
+# by the root pyproject.toml [tool.uv] required-version range.
+# Run 'uv run --no-project scripts/tasks.py check-uv-version' to verify the policy.
 #
 # Build context MUST be the repository root because the workspace lockfile lives at the
 # repository root. Build with:


### PR DESCRIPTION
開発hostのuvをDockerと同じpatch版へ完全固定していたため、互換性のあるpatch更新でも通常の検証作業が停止していました。hostの互換性と、CIや成果物生成の再現性を別の契約として扱います。

## 変更内容

- hostは`pyproject.toml`で定義した単一minor seriesの互換範囲を許可
- Docker、CI、lock更新workflowは互換範囲の下限へ固定
- `check-uv-version`でDockerの実`FROM`命令と、全workflowの`setup-uv`にある`with.version`を検査
- 境界値、Docker pin、workflow pinの回帰テストを追加
- 文書は具体的なversionを重複記載せず、設定の正本と管理方針を説明

## 確認

- host uv 0.12.3で`check-uv-version`成功
- 対象テスト4件成功
- Ruff lint、format check成功
- 固定版uvとpublic設定によるlock check成功
- `uv.lock`に差分なし