### PR TITLE
docs: align repository guidance and workarounds

### DIFF
--- a/.github/agents/design-snapshot.agent.md
+++ b/.github/agents/design-snapshot.agent.md
@@ -9,7 +9,7 @@ description: 現在の IaC と ADR から設計書スナップショットを生
 
 以下を読み取る:
 - `infra/main.bicep` — 現在のインフラ構成
-- `infra/main.bicepparam` — パラメータ設定
+- `infra/main.parameters.json` — subscription scope のパラメータ設定
 - `k8s/apps/chaos-app/` — chaos-app Kubernetes マニフェスト
 - `docs/adr/` — 確定済みの設計判断
 - `.github/copilot-instructions.md` — プロジェクト概要と規約

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -20,6 +20,8 @@ AKS 上の Chaos Engineering ラボ環境。azd でインフラとアプリを�
 ```
 pyproject.toml    # uv workspace ルート (ruff/ty 共通設定、開発用依存)
 uv.lock           # workspace 共通ロック
+.github/          # agents, skills, hooks, workflows
+scripts/          # QA・デプロイ・クリーンアップのタスク
 src/api/          # FastAPI アプリ (uv member: aks-chaos-lab-api)
 src/api/app/      # main.py, config.py, models.py, redis_client.py 等
 src/api/Dockerfile # build context = repo root, `uv export` + `uv pip sync` で API 依存を導入
@@ -69,6 +71,9 @@ docs/features/    # Feature Document（作業途中の状態保存）
 - `docs/features/` — 作業中の Feature Document。決定事項・制約を尊重する
 - `docs/deployment.md` — 構築・削除・検証手順
 - `docs/observability.md` — 可観測性の運用詳細
+- `docs/chaos-experiments.md` — Chaos 実験の実行手順
+- `docs/workarounds.md` — 継続中のワークアラウンドと解消条件
+- `.github/skills/` — リポジトリ固有タスクの詳細な実行手順
 - `infra/` — 現在のインフラ構成（Bicep）
 - `src/` — 現在のアプリケーションコード
 - `k8s/` — 現在の Kubernetes マニフェスト

--- a/docs/workarounds.md
+++ b/docs/workarounds.md
@@ -174,3 +174,12 @@ ID は履歴追跡用に固定する。削除済み ID は再利用しない。
 - **解消条件**: Microsoft 側で `prometheus-collector` image の supervisor が replica pod でも `AMACoreAgent` を起動する、あるいは OTLP DCR 配信を replica pod 対象から除外する修正が入る。
 - **確認方法**: image tag の更新後に `kubectl -n kube-system exec <ama-metrics-pod> -c prometheus-collector -- ps -ef | grep amacoreagent` と `mdsd.err` を確認する。
 - **追跡**: [#130](https://github.com/torumakabe/aks-chaos-lab/issues/130)（実害なしと判定済み・closed）。
+
+### D-9. `ErrorAwareSampler` は span 終了後の ERROR を判定できない
+
+- **概要**: `OTEL_TRACES_SAMPLER` が未設定の場合、API は `ParentBased(ErrorAwareSampler)` を使用する。この sampler は親のない root span の name または HTTP path attribute に `chaos`、`error`、`throw` を含む場合に常にサンプルし、それ以外を `TELEMETRY_SAMPLING_RATE` に従って判定する。親 span がある場合は親の sampling decision を継承するため、キーワードを含むリクエストでも未サンプルの親を継承すると保持されない。キーワードを含まないリクエストが span 終了時に ERROR となった場合も、その trace が保持される保証はない。
+- **理由**: OpenTelemetry SDK は sampler を span 開始時に呼び出すため、span 終了時に設定される `status=ERROR` を判定材料にできない。リポジトリには Collector 側の tail-based sampling 構成がなく、アプリ側のキーワード判定は欠落を減らすための限定的な回避策である。
+- **場所**: `src/api/app/telemetry.py` の `ErrorAwareSampler`、`src/api/tests/unit/test_telemetry.py`
+- **解消条件**: SDK 側で全 span を Collector へ送り、Collector 側で `status=ERROR` を条件にした tail-based sampling を構成して、キーワードに依存せず ERROR trace を保持できるようになる。または OpenTelemetry SDK が span 終了時の状態に基づく sampling を提供する。
+- **確認方法**: `uv run pytest src/api/tests/unit/test_telemetry.py -k error_aware_sampler` でキーワード判定と ratio-based 判定を確認する。tail-based sampling を導入する場合は、キーワードを含まないエンドポイントでエラーを発生させ、Collector と Application Insights で該当 trace が保持されることを確認する。
+- **最終確認**: 2026-08-10、リポジトリ内に tail-based sampling 構成はなく、`ErrorAwareSampler` の単体テストはキーワード判定と ratio-based 判定を対象としている。

--- a/src/api/app/telemetry.py
+++ b/src/api/app/telemetry.py
@@ -71,9 +71,10 @@ class ErrorAwareSampler(Sampler):
     SDK の sampler は span 開始時にしか呼ばれないため、span 終了時の
     ``status=ERROR`` を直接判定できない。本サンプラーは現実解として、
     chaos / error / throw を含む span name や HTTP attribute を持つ
-    リクエストを 100% サンプル対象とすることで、障害調査時に該当 trace
-    が引けない問題を緩和する。post-hoc な ERROR 保証は Collector 側の
-    tail-based sampling に委ねる (docs/workarounds.md 参照)。
+    root span を 100% サンプル対象とすることで、障害調査時に該当 trace
+    が引けない問題を緩和する。ParentBased で未サンプルの親を継承する場合や、
+    span 終了後に確定する ERROR の完全な捕捉は保証しない
+    (docs/workarounds.md D-9 参照)。
     """
 
     _ALWAYS_PATTERNS: tuple[str, ...] = (
@@ -203,9 +204,9 @@ def setup_telemetry(app: Any) -> None:
       (auto-injected by AKS Instrumentation CRD, or set manually)
     - Sampling: env var OTEL_TRACES_SAMPLER (AKS auto-config) を優先。
       未設定時は TELEMETRY_SAMPLING_RATE を base rate にした
-      ParentBased(ErrorAwareSampler(rate)) を採用し、parent が sampled なら
-      子も sampled、chaos/error 系 path は base rate を無視して 100% sample
-      する。
+      ParentBased(ErrorAwareSampler(rate)) を採用し、parent の sampling
+      decision を継承する。親のない chaos/error 系 path は base rate を
+      無視して 100% sample する。
     - Export interval: TELEMETRY_EXPORT_INTERVAL_MS (デフォルト 30s) で
       MeterReader の export 周期を制御し、低トラフィック時の signal 鮮度を
       確保する。


### PR DESCRIPTION
## 概要

リポジトリ内のAI向け案内とワークアラウンド棚卸しを、現在の実装に一致させます。

## 変更内容

- `design-snapshot` の存在しない `infra/main.bicepparam` 参照を `infra/main.parameters.json` へ修正
- Copilot instructionsへ主要な知識ソースとタスク配置を追加
- `ErrorAwareSampler` が保証できるsampling範囲を正確に記述
- span終了後に確定するERRORを完全には捕捉できない制約を `D-9` として追加

## 確認内容

- samplerの対象単体テスト
- Ruff
- 参照先パスの存在確認
- `git diff --check`