### PR TITLE
chore: update Bicep CLI to v0.46.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Install Bicep CLI
         run: |
           set -euxo pipefail
-          BICEP_VERSION=v0.45.15
+          BICEP_VERSION=v0.46.1
           mkdir -p "$HOME/.local/bin"
           curl -L -o "$HOME/.local/bin/bicep" "https://github.com/Azure/bicep/releases/download/${BICEP_VERSION}/bicep-linux-x64"
           chmod +x "$HOME/.local/bin/bicep"


### PR DESCRIPTION
## 変更内容

- `.github/workflows/ci.yml` の CI 固定 Bicep CLI を `v0.45.15` から `v0.46.1` へ更新

## 変更不要と判断した箇所

- `.github/workflows/bicep-version-check.yml` は `ci.yml` から固定版を抽出するため現状維持
- `.github/workflows/integration-test.yml` は Azure CLI 組み込みの Bicep を使用するため現状維持

## 検証

一時的な `AZURE_CONFIG_DIR` に Bicep CLI v0.46.1 を隔離インストールし、次を確認しました。

- `az bicep restore --file infra/main.bicep`: 成功
- `az bicep build --file infra/main.bicep`: 成功
- `uv run --no-project "$PWD\scripts\tasks.py" build-bicep`: 成功