### PR TITLE
Adopt AKS Node Auto Provisioning for Arm64 capacity

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -84,6 +84,8 @@ docs/features/    # Feature Document（作業途中の状態保存）
 - セッションの区切りでは `wrap-up` エージェントで ADR 候補の洗い出し・Feature Document の要否判断・リトマステストを行う
 - 複雑な機能は実装前に段階的な設計会話を行う（要件確認 → コンポーネント設計 → データフロー → インターフェース定義 → 実装）。コードは設計合意後
 - ユーザーから見える振る舞いが変わる変更（機能追加、API 変更、デプロイ手順変更、アーキテクチャ変更）では README.md または該当する `docs/*.md` の更新要否を確認し、必要なら同一 PR 内で更新する
+- buildまたはdeployの失敗を理由に新しい経路を実装する前に、`docs/deployment.md`、関連ADR、対象CLIの`--help`を確認する。既存のbuild済みartifactを渡す経路を含め、現在の機能を組み合わせて解決できるか再現してから、リポジトリ変更の要否を判断する
+- 組織承認済みpackage indexを使うAPI imageのbuildとAKSへのdeployは、`docs/deployment.md`の「Docker build のpackage index」を正本とする。手順を重複記載せず、別のpackage index連携を追加する場合は既存手順では解決できない条件を先に記録する
 - ドキュメントは `docs/` に配置。一時ファイルは `tmp/` に配置し、完了後に削除
 
 ## 事実検証

--- a/.github/skills/bicep-what-if-analysis/scripts/patterns/pattern_stats.json
+++ b/.github/skills/bicep-what-if-analysis/scripts/patterns/pattern_stats.json
@@ -1,39 +1,39 @@
 {
   "patterns": {
     "Microsoft.Network/virtualNetworks:custom_patterns:^subnets\\..*\\.properties\\.networkSecurityGroup$": {
-      "matchCount": 42,
+      "matchCount": 43,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^identityProfile$": {
-      "matchCount": 45,
+      "matchCount": 46,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.powerState$": {
-      "matchCount": 45,
+      "matchCount": 46,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^aadProfile\\.tenantID$": {
-      "matchCount": 45,
+      "matchCount": 46,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.Network/publicIPAddresses:auto_managed_patterns:^ddosSettings$": {
-      "matchCount": 45,
+      "matchCount": 46,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^servicePrincipalProfile$": {
-      "matchCount": 45,
+      "matchCount": 46,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^controlPlanePluginProfiles$": {
-      "matchCount": 45,
+      "matchCount": 46,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^ingressProfile\\.webAppRouting\\.nginx$": {
       "matchCount": 35,
@@ -46,34 +46,34 @@
       "lastMatched": "2026-08-06T09:14:49.994841+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^networkProfile\\.advancedNetworking\\.security\\.transitEncryption$": {
-      "matchCount": 44,
+      "matchCount": 45,
       "firstMatched": "2026-01-28T07:27:16.893220+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.ContainerService/managedClusters:custom_patterns:^agentPoolProfiles\\[\\d+\\]\\.orchestratorVersion$": {
-      "matchCount": 43,
+      "matchCount": 44,
       "firstMatched": "2026-01-28T07:27:16.893220+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^networkProfile\\.podCidrs$": {
-      "matchCount": 44,
+      "matchCount": 45,
       "firstMatched": "2026-01-28T07:27:16.893220+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^networkProfile\\.serviceCidrs$": {
-      "matchCount": 44,
+      "matchCount": 45,
       "firstMatched": "2026-01-28T07:27:16.893220+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.osDiskSizeGB$": {
-      "matchCount": 40,
+      "matchCount": 41,
       "firstMatched": "2026-01-28T07:36:35.396763+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.upgradeSettings$": {
-      "matchCount": 40,
+      "matchCount": 41,
       "firstMatched": "2026-01-28T07:36:35.396763+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.osSKU$": {
       "matchCount": 30,
@@ -81,29 +81,29 @@
       "lastMatched": "2026-03-18T04:33:16.070546+00:00"
     },
     "Microsoft.ContainerRegistry/registries:auto_managed_patterns:^roleAssignmentMode$": {
-      "matchCount": 40,
+      "matchCount": 41,
       "firstMatched": "2026-01-28T07:36:35.396763+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.securityProfile$": {
-      "matchCount": 40,
+      "matchCount": 41,
       "firstMatched": "2026-01-28T07:36:35.396763+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.osDiskType$": {
-      "matchCount": 40,
+      "matchCount": 41,
       "firstMatched": "2026-01-28T07:36:35.396763+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^autoScalerProfile\\.skip-nodes-with-local-storage$": {
-      "matchCount": 40,
+      "matchCount": 41,
       "firstMatched": "2026-01-28T07:36:35.396763+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^securityProfile\\.defender$": {
-      "matchCount": 39,
+      "matchCount": 40,
       "firstMatched": "2026-01-28T07:40:32.040732+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.count$": {
       "matchCount": 39,
@@ -111,9 +111,9 @@
       "lastMatched": "2026-08-06T09:14:49.994841+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^storageProfile$": {
-      "matchCount": 39,
+      "matchCount": 40,
       "firstMatched": "2026-01-28T07:40:32.040732+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^addonProfiles$": {
       "matchCount": 37,
@@ -121,44 +121,44 @@
       "lastMatched": "2026-05-18T23:19:10.964598+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^securityProfile\\.imageCleaner$": {
-      "matchCount": 31,
+      "matchCount": 32,
       "firstMatched": "2026-01-28T07:40:32.040732+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.Network/virtualNetworks:auto_managed_patterns:^privateEndpointVNetPolicies$": {
-      "matchCount": 39,
+      "matchCount": 40,
       "firstMatched": "2026-01-28T07:40:32.040732+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^windowsProfile$": {
-      "matchCount": 39,
+      "matchCount": 40,
       "firstMatched": "2026-01-28T07:40:32.040732+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^serviceMeshProfile$": {
-      "matchCount": 30,
+      "matchCount": 31,
       "firstMatched": "2026-02-02T09:46:15.864264+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.ContainerRegistry/registries:auto_managed_patterns:^networkRuleBypassAllowedForTasks$": {
-      "matchCount": 27,
+      "matchCount": 28,
       "firstMatched": "2026-03-04T00:59:09.421623+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.Network/publicIPAddresses:auto_managed_patterns:^ipTags$": {
-      "matchCount": 17,
+      "matchCount": 18,
       "firstMatched": "2026-03-04T00:59:09.421623+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.Network/virtualNetworks/subnets/providers/roleAssignments:auto_managed_patterns:^principalId$": {
-      "matchCount": 26,
+      "matchCount": 27,
       "firstMatched": "2026-03-04T01:01:54.287895+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.Network/virtualNetworks/subnets/providers/roleAssignments:auto_managed_patterns:^principalType$": {
-      "matchCount": 26,
+      "matchCount": 27,
       "firstMatched": "2026-03-04T01:01:54.287895+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.ContainerService/managedClusters:custom_patterns:^kubernetesVersion$": {
       "matchCount": 9,
@@ -166,9 +166,9 @@
       "lastMatched": "2026-05-18T23:19:10.964598+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^networkProfile\\.advancedNetworking\\.performance$": {
-      "matchCount": 11,
+      "matchCount": 12,
       "firstMatched": "2026-03-18T04:33:16.070546+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.upgradeSettingsBlueGreen$": {
       "matchCount": 1,
@@ -176,14 +176,14 @@
       "lastMatched": "2026-03-18T04:33:16.070546+00:00"
     },
     "Microsoft.Chaos/experiments:auto_managed_patterns:^tags$": {
-      "matchCount": 11,
+      "matchCount": 12,
       "firstMatched": "2026-03-18T04:33:16.070546+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.Chaos/experiments:auto_managed_patterns:^steps\\.\\d+\\.branches\\.\\d+\\.actions\\.\\d+\\.parameters\\.\\d+\\.value$": {
-      "matchCount": 11,
+      "matchCount": 12,
       "firstMatched": "2026-03-18T04:33:16.070546+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.upgradeStrategy$": {
       "matchCount": 1,
@@ -191,49 +191,49 @@
       "lastMatched": "2026-03-18T04:33:16.070546+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^ingressProfile\\.webAppRouting\\.defaultDomain$": {
-      "matchCount": 11,
+      "matchCount": 12,
       "firstMatched": "2026-03-18T04:33:16.070546+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^nodeDisruptionProfile$": {
-      "matchCount": 7,
+      "matchCount": 8,
       "firstMatched": "2026-05-18T23:06:29.633543+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.OperationalInsights/workspaces/tables:auto_managed_patterns:^retentionInDays$": {
-      "matchCount": 7,
+      "matchCount": 8,
       "firstMatched": "2026-05-18T23:06:29.633543+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.OperationalInsights/workspaces/tables:auto_managed_patterns:^totalRetentionInDays$": {
-      "matchCount": 7,
+      "matchCount": 8,
       "firstMatched": "2026-05-18T23:06:29.633543+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.ContainerService/fleets/autoUpgradeProfiles:auto_managed_patterns:^longTermSupport$": {
-      "matchCount": 7,
+      "matchCount": 8,
       "firstMatched": "2026-05-18T23:06:29.633543+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.ContainerService/fleets/members:auto_managed_patterns:^labels$": {
-      "matchCount": 7,
+      "matchCount": 8,
       "firstMatched": "2026-05-18T23:06:29.633543+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.Cache/redisEnterprise/databases:auto_managed_patterns:^redisVersion$": {
-      "matchCount": 7,
+      "matchCount": 8,
       "firstMatched": "2026-05-18T23:06:29.633543+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^healthMonitorProfile$": {
-      "matchCount": 7,
+      "matchCount": 8,
       "firstMatched": "2026-05-18T23:06:29.633543+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.ContainerService/fleets/updateStrategies:auto_managed_patterns:^strategy\\.stages\\.\\d+\\.afterStageWaitInSeconds$": {
-      "matchCount": 7,
+      "matchCount": 8,
       "firstMatched": "2026-05-18T23:06:29.633543+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^azureMonitorProfile\\.metrics\\.controlPlane$": {
       "matchCount": 5,
@@ -241,129 +241,129 @@
       "lastMatched": "2026-05-18T23:19:10.964598+00:00"
     },
     "Microsoft.Network/privateDnsZones/virtualNetworkLinks:auto_managed_patterns:^resolutionPolicy$": {
-      "matchCount": 7,
+      "matchCount": 8,
       "firstMatched": "2026-05-18T23:06:29.633543+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.Authorization/roleAssignments:auto_managed_patterns:^principalType$": {
-      "matchCount": 6,
+      "matchCount": 7,
       "firstMatched": "2026-05-18T23:11:17.563406+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.Authorization/roleAssignments:auto_managed_patterns:^principalId$": {
-      "matchCount": 6,
+      "matchCount": 7,
       "firstMatched": "2026-05-18T23:11:17.563406+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.Insights/scheduledQueryRules:auto_managed_patterns:^windowSize$": {
-      "matchCount": 5,
+      "matchCount": 6,
       "firstMatched": "2026-05-18T23:13:14.888125+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.ContainerService/managedClusters/providers/diagnosticSettings:auto_managed_patterns:^metrics$": {
-      "matchCount": 4,
+      "matchCount": 5,
       "firstMatched": "2026-05-18T23:15:22.306674+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.ContainerService/managedClusters/providers/diagnosticSettings:auto_managed_patterns:^logs\\.\\d+$": {
-      "matchCount": 4,
+      "matchCount": 5,
       "firstMatched": "2026-05-18T23:15:22.306674+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.ContainerService/managedClusters/providers/diagnosticSettings:auto_managed_patterns:^logs\\.\\d+\\.retentionPolicy\\.days$": {
-      "matchCount": 4,
+      "matchCount": 5,
       "firstMatched": "2026-05-18T23:15:22.306674+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.ContainerService/managedClusters/providers/dataCollectionRuleAssociations:auto_managed_patterns:^dataCollectionRuleId$": {
-      "matchCount": 4,
+      "matchCount": 5,
       "firstMatched": "2026-05-18T23:15:22.306674+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.Monitor/accounts/providers/roleAssignments:auto_managed_patterns:^principalId$": {
-      "matchCount": 2,
+      "matchCount": 3,
       "firstMatched": "2026-08-06T08:49:48.172598+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.Monitor/accounts/providers/roleAssignments:auto_managed_patterns:^principalType$": {
-      "matchCount": 2,
+      "matchCount": 3,
       "firstMatched": "2026-08-06T08:49:48.172598+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.Insights/dataCollectionRules/providers/roleAssignments:auto_managed_patterns:^principalId$": {
-      "matchCount": 2,
+      "matchCount": 3,
       "firstMatched": "2026-08-06T08:49:48.172598+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^hostedSystemProfile$": {
-      "matchCount": 2,
+      "matchCount": 3,
       "firstMatched": "2026-08-06T08:49:48.172598+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.ContainerService/managedClusters/providers/extensions:auto_managed_patterns:^aksAssignedIdentity$": {
-      "matchCount": 2,
+      "matchCount": 3,
       "firstMatched": "2026-08-06T08:49:48.172598+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.ContainerService/managedClusters/providers/extensions:custom_patterns:^scope$": {
-      "matchCount": 2,
+      "matchCount": 3,
       "firstMatched": "2026-08-06T08:49:48.172598+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^addonProfiles\\.omsagent$": {
-      "matchCount": 2,
+      "matchCount": 3,
       "firstMatched": "2026-08-06T08:49:48.172598+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.Insights/dataCollectionRules/providers/roleAssignments:auto_managed_patterns:^principalType$": {
-      "matchCount": 2,
+      "matchCount": 3,
       "firstMatched": "2026-08-06T08:49:48.172598+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.Storage/storageAccounts/providers/roleAssignments:auto_managed_patterns:^principalId$": {
-      "matchCount": 2,
+      "matchCount": 3,
       "firstMatched": "2026-08-06T08:49:48.172598+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.Storage/storageAccounts/blobServices/containers:auto_managed_patterns:^defaultEncryptionScope$": {
-      "matchCount": 2,
+      "matchCount": 3,
       "firstMatched": "2026-08-06T08:49:48.172598+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.ContainerService/managedClusters/providers/extensions:auto_managed_patterns:^managementDetails$": {
-      "matchCount": 2,
+      "matchCount": 3,
       "firstMatched": "2026-08-06T08:49:48.172598+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^ingressProfile\\.webAppRouting\\.nginx\\.mode$": {
-      "matchCount": 2,
+      "matchCount": 3,
       "firstMatched": "2026-08-06T08:49:48.172598+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.Storage/storageAccounts/blobServices/containers:auto_managed_patterns:^denyEncryptionScopeOverride$": {
-      "matchCount": 2,
+      "matchCount": 3,
       "firstMatched": "2026-08-06T08:49:48.172598+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.Storage/storageAccounts/blobServices:auto_managed_patterns:^properties$": {
-      "matchCount": 2,
+      "matchCount": 3,
       "firstMatched": "2026-08-06T08:49:48.172598+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.ContainerService/managedClusters/providers/extensions:auto_managed_patterns:^extensionState$": {
-      "matchCount": 2,
+      "matchCount": 3,
       "firstMatched": "2026-08-06T08:49:48.172598+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^addonProfiles\\.extensionManager$": {
-      "matchCount": 2,
+      "matchCount": 3,
       "firstMatched": "2026-08-06T08:49:48.172598+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.Storage/storageAccounts/providers/roleAssignments:auto_managed_patterns:^principalType$": {
-      "matchCount": 2,
+      "matchCount": 3,
       "firstMatched": "2026-08-06T08:49:48.172598+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     },
     "Microsoft.Management/serviceGroups/providers/slis:custom_patterns:^sliProperties\\.(goodSignals|totalSignals)\\.signalSources\\.\\d+\\.temporalAggregation\\.windowSizeMinutes$": {
       "matchCount": 1,
@@ -371,10 +371,10 @@
       "lastMatched": "2026-08-06T08:50:08.427862+00:00"
     },
     "Microsoft.ContainerService/managedClusters/providers/extensions:custom_patterns:^autoUpgradeMode$": {
-      "matchCount": 1,
+      "matchCount": 2,
       "firstMatched": "2026-08-06T09:14:49.994841+00:00",
-      "lastMatched": "2026-08-06T09:14:49.994841+00:00"
+      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
     }
   },
-  "lastRun": "2026-08-06T09:14:49.994841+00:00"
+  "lastRun": "2026-08-21T04:34:47.827444+00:00"
 }

--- a/azure.yaml
+++ b/azure.yaml
@@ -111,6 +111,14 @@ services:
       namespace: kube-system
       kustomize:
         dir: k8s/observability
+  node-provisioning:
+    project: .
+    host: aks
+    resourceName: ${AZURE_AKS_CLUSTER_NAME}
+    k8s:
+      namespace: kube-system
+      kustomize:
+        dir: k8s/node-provisioning
   external-sli-publisher:
     project: src/external-sli-publisher
     language: python

--- a/docs/adr/018-adopt-aks-node-auto-provisioning-for-arm64-capacity.md
+++ b/docs/adr/018-adopt-aks-node-auto-provisioning-for-arm64-capacity.md
@@ -1,0 +1,47 @@
+# ADR-018: NAPをArm64 workloadの追加capacityに採用する
+
+- Status: Accepted
+- Date: 2026-08-21
+
+## Context
+
+Japan Eastで特定のVM SKUを割り当てられない場合にも、Arm64の`chaos-app`を実行できる追加capacityが必要である。ノードはEphemeral OS Diskを維持する。
+
+AKS Standardでは、NAPを有効にしても従来型のSystem AgentPoolが必要である。NAPはSystem workload用ノードも作成できるが、System AgentPoolそのものを置き換えられない。このため、NAPだけではAKS全体の割り当て耐性を確保できない。
+
+一方、NAPは`Standard_D4pds_v5`と`Standard_D4pds_v6`を別々のNodeClaimとして作成できる。両SKUはEphemeral OS Diskのplacementが異なるため、単一のVirtual Machines multi-SKU AgentPoolには混在できない。
+
+## Decision
+
+1. AKS StandardでNAPを採用し、Arm64 User workloadの追加capacityを作成する。
+2. 既存のArm64 System AgentPoolを2台で維持する。System workloadのcapacityはNAPへ移さない。
+3. NAPのNodePoolは`Standard_D4pds_v5`または`Standard_D4pds_v6`、on-demand、Ephemeral OS Diskを条件とする。
+4. NAPとCluster Autoscalerは併用しない。NAPのfeature flagは既定で無効にする。
+5. SKUの選択順序、`AllocationFailed`後の別SKUへの再試行、zoneの切り替え順序は保証事項として扱わない。
+6. 初期導入時のNodePool resource limitは8 vCPUとする。候補SKUはいずれも4 vCPUのため、通常は2台分に相当する。ただし、Karpenterのlimit判定はeventual consistencyであり、急なscale-outでは一時的に上限を超える可能性があるため、厳密なノード数上限として扱わない。
+7. consolidationは空ノードだけを対象とし、node expirationは無効にする。voluntary disruptionは同時1台までに制限する。
+
+## Consequences
+
+- User workloadには、異なるEphemeral OS Disk placementを持つv5とv6を追加capacityの候補として提供できる。
+- 固定System AgentPoolの割り当て失敗や修復不能には対応できない。
+- 別SKUまたは別zoneへのfallbackは保証されない。
+- custom taintを設定しないため、制約が一致する`kube-system` PodがNAP nodeへ配置される可能性がある。System AgentPoolを2台維持する判断は、System Podの排他的な配置を保証しない。
+- 稼働中のworkloadを低利用率だけを理由に移動しないため、`WhenEmptyOrUnderutilized`よりも余剰capacityが残る場合がある。
+- 8 vCPUのresource limitは費用の目安にはなるが、急なscale-out時の一時超過を防ぐ厳密なコスト上限にはならない。
+- 8 vCPUを超える追加capacityが必要な場合は、費用とsubnet IPへの影響を確認してからlimitを変更する必要がある。
+- 新規NAP nodeでは、`ama-logs`のOTLP listenerがReadyになる前にworkloadが起動し、最初のlog batchが失われる場合がある。collectorがReadyになった後のログ収集は回復するため、監査用途ではない起動ログに限る既知の制約として受容する。
+- System AgentPoolの固定費と、NAPの監視および障害調査の運用負荷が残る。
+
+NAPの採用により、Arm64 User workloadはv5とv6を追加capacityの候補にできる。ただし、固定System AgentPoolをNAPへ移さないため、この判断だけではAKS全体の割り当てエラーを回避できない。
+
+## 採用しなかった代替案
+
+- **v5とv6を単一Virtual Machines multi-SKU AgentPoolへ入れる**: 異なるEphemeral OS Disk placementを混在できない。
+- **System workloadにもNAPを使用する**: 必須のSystem AgentPoolを削減できず、管理対象だけが増える。
+- **Managed OS Diskへ変更する**: Ephemeral OS Diskを維持する要件を満たさない。
+
+## 関連 ADR
+
+- ADR-008: System AgentPoolのUbuntu 24.04指定を維持する。
+- ADR-010: AKS Automaticを採用せず、AKS Standardを維持する。

--- a/docs/adr/INDEX.md
+++ b/docs/adr/INDEX.md
@@ -19,3 +19,4 @@
 | 015 | [Azure リソース名への resourceToken サフィックス付与ルール](015-resource-token-suffix-naming.md) | Accepted | 2026-06-28 |
 | 016 | [Azure Chaos Studio Workspace の採用](016-azure-chaos-studio-workspace-adoption.md) | Rejected | 2026-07-16 |
 | 017 | [管理対象環境向け approved-index 変換フロー (ADR-013 の一部を amend)](017-approved-index-conversion-for-managed-environments.md) | Accepted | 2026-08-08 |
+| 018 | [NAPをArm64 workloadの追加capacityに採用する](018-adopt-aks-node-auto-provisioning-for-arm64-capacity.md) | Accepted | 2026-08-21 |

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -141,6 +141,62 @@ azd env set AZURE_LOCATION japaneast -e eval
 azd env set AZURE_AKS_NODE_VM_SIZE Standard_D4pds_v6 -e eval
 ```
 
+### Node Auto Provisioning
+
+Node Auto Provisioning（NAP）は既定で無効です。設計判断と採用条件は[ADR-018](adr/018-adopt-aks-node-auto-provisioning-for-arm64-capacity.md)を参照してください。
+
+NAPを有効にする場合は、対象環境へ明示的に設定してからbase layerの差分を確認します。NAP有効時はSystem AgentPoolがArm64 2台固定となり、Cluster Autoscalerは無効になります。
+
+```bash
+azd env refresh -e eval --no-prompt
+azd env set AZURE_AKS_ENABLE_NODE_AUTO_PROVISIONING true -e eval
+azd provision base --preview -e eval
+```
+
+既存環境のpreviewにAKS以外の意図しない変更、またはSystem AgentPoolの削除や置換が含まれる場合は、base layerを適用しません。Azure PolicyがsubnetへBicep管理外のNSGを関連付ける環境では、previewにNSG関連付けの削除が表示されます。対象NSGがポリシー管理であり、subnetの名前、address prefix、delegationに変更がないことを確認した場合は、期待されたdriftとして扱います。
+
+既存AKSだけを移行するときは、System AgentPoolのCluster Autoscalerを無効化してから、AKSのnode provisioning profileだけを更新します。
+
+```bash
+RESOURCE_GROUP="$(azd env get-value AZURE_RESOURCE_GROUP -e eval)"
+AKS_NAME="$(azd env get-value AZURE_AKS_CLUSTER_NAME -e eval)"
+
+az aks nodepool update \
+  --resource-group "$RESOURCE_GROUP" \
+  --cluster-name "$AKS_NAME" \
+  --name default \
+  --disable-cluster-autoscaler
+
+az aks update \
+  --resource-group "$RESOURCE_GROUP" \
+  --name "$AKS_NAME" \
+  --node-provisioning-mode Auto \
+  --node-provisioning-default-pools None
+```
+
+System AgentPoolが2台Readyで、既存workloadが健全であることを確認します。NAP resourceは既定の`azd up` workflowへ含めていません。AKS側にNAPのCRDが作成されたことを確認してから、User workload用のAKSNodeClassとNodePoolを明示的に適用します。
+
+```bash
+kubectl wait \
+  --for=condition=Established \
+  crd/nodepools.karpenter.sh \
+  crd/aksnodeclasses.karpenter.azure.com \
+  --timeout=10m
+
+azd deploy node-provisioning -e eval
+```
+
+無効化するときは、次の順序で操作します。System AgentPoolは全工程で2台を維持します。
+
+1. NAP capacityを必要とするUser workloadを停止する。
+2. User NodeClaimが0台になったことを確認する。
+3. `kubectl delete -k k8s/node-provisioning`でNodePoolとAKSNodeClassを削除する。
+4. `az aks update --node-provisioning-mode Manual`でNAPを無効化する。
+5. `az aks nodepool update --enable-cluster-autoscaler --min-count 1 --max-count 3`でSystem AgentPoolのCluster Autoscalerを復元する。
+6. System AgentPool、既存workload、外部health endpointを確認する。
+7. `AZURE_AKS_ENABLE_NODE_AUTO_PROVISIONING`を`false`へ戻す。
+8. `azd provision base --preview -e eval`を実行し、NAPに関する差分が解消したことを確認する。ポリシー管理のNSG関連付けは期待されたdriftとして残る場合がある。
+
 ## ローカル開発
 
 リポジトリは uv workspace 構成です。hostはルート`pyproject.toml`の互換範囲に従います。CI、Docker、lock更新workflowは、再現性を維持するため互換範囲の下限へ固定します。`check-uv-version`はこの関係を検査します。ルートで一度同期すれば、`src/api` と `src/external-sli-publisher` の両方の依存と開発ツール (ruff / ty / pytest / locust) が揃います。
@@ -185,7 +241,9 @@ PowerShellでは `$env:UV_NO_SYNC = "1"` を設定します。
 docker build -f src/api/Dockerfile -t aks-chaos-lab:local .
 ```
 
-組織承認済みpackage indexが必要な管理対象環境では、ローカルbuildに限りuser-level `uv.toml` をBuildKit secretとして渡します。このsecretを公開CIへ渡してはいけません。
+組織承認済みpackage indexが必要な管理対象環境では、ローカルbuildに限りuser-level `uv.toml`をBuildKit secretとして渡します。このsecretを公開CIへ渡してはいけません。
+
+次のPOSIX shell例は、API imageをローカルに作成します。
 
 ```bash
 UV_CONFIG_PATH="$HOME/.config/uv/uv.toml"
@@ -199,6 +257,39 @@ docker build \
   -f src/api/Dockerfile \
   -t aks-chaos-lab:local .
 ```
+
+PowerShellでは、次を実行します。
+
+```powershell
+$UvConfigPath = Join-Path $env:APPDATA "uv\uv.toml"
+$ApprovedIndexConfigScript = Join-Path $PWD "scripts\approved_index_config.py"
+$UvIndexConfigSha256 = uv run --no-project `
+  $ApprovedIndexConfigScript digest $UvConfigPath
+docker build `
+  --build-arg "UV_INDEX_MODE=approved-index" `
+  --build-arg "UV_INDEX_CONFIG_SHA256=$UvIndexConfigSha256" `
+  --secret "id=uv-config,src=$UvConfigPath" `
+  -f src/api/Dockerfile `
+  -t aks-chaos-lab:local .
+```
+
+管理対象環境からAKSへdeployする場合は、対象のazd environmentを選択し、OpenTelemetry instrumentationを適用してから、作成済みimageを`--from-package`へ渡します。
+
+```bash
+azd env select <environment>
+azd deploy api-instrumentation --no-prompt
+azd deploy api --from-package aks-chaos-lab:local --no-prompt
+```
+
+PowerShellでは、次を実行します。
+
+```powershell
+azd env select <environment>
+azd deploy api-instrumentation --no-prompt
+azd deploy api --from-package aks-chaos-lab:local --no-prompt
+```
+
+`azd deploy api`を`--from-package`なしで実行すると、azdはDocker imageを再buildします。現在の`azure.yaml`はBuildKit secretをazdのbuildへ渡さないため、そのbuildはpublic PyPIを使用します。管理対象環境では、approved indexで作成したローカルimageを`--from-package`で指定してください。
 
 configのSHA-256はdependency layerとcache mountのkeyになります。Dockerfileはmountしたconfigのhashを照合するため、configを変更すると古いlayerを再利用しません。build logを共有する前に、index URLや認証情報が含まれていないことを確認してください。
 

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -12,6 +12,9 @@ param environment string = 'dev'
 @description('AKS node VM size')
 param nodeVmSize string = 'Standard_D4pds_v6'
 
+@description('Enable AKS Node Auto Provisioning for user workload capacity')
+param enableNodeAutoProvisioning bool = false
+
 @description('Virtual network address prefix')
 param vnetAddressPrefix string = '10.10.0.0/16'
 
@@ -398,6 +401,7 @@ module aksCluster './modules/aks.bicep' = {
     tags: tags
     aksName: aksClusterName
     nodeVmSize: nodeVmSize
+    enableNodeAutoProvisioning: enableNodeAutoProvisioning
     aksSubnetId: network.outputs.aksSubnetId
     aksApiSubnetId: network.outputs.aksApiSubnetId
     kubernetesVersion: kubernetesVersion

--- a/infra/main.parameters.json
+++ b/infra/main.parameters.json
@@ -14,6 +14,9 @@
     "nodeVmSize": {
       "value": "${AZURE_AKS_NODE_VM_SIZE:Standard_D4pds_v6}"
     },
+    "enableNodeAutoProvisioning": {
+      "value": "${AZURE_AKS_ENABLE_NODE_AUTO_PROVISIONING:false}"
+    },
     "vnetAddressPrefix": {
       "value": "10.10.0.0/16"
     },

--- a/infra/modules/aks.bicep
+++ b/infra/modules/aks.bicep
@@ -10,6 +10,8 @@ param kubernetesVersion string = '1.35'
 param nodeResourceGroupName string
 @description('Node VM size')
 param nodeVmSize string
+@description('Enable AKS Node Auto Provisioning for user workload capacity')
+param enableNodeAutoProvisioning bool = false
 @description('AKS subnet id')
 param aksSubnetId string
 @description('AKS API Server subnet id')
@@ -131,11 +133,19 @@ var aksBaseSpecificProperties = {
   autoUpgradeProfile: {
     nodeOSUpgradeChannel: 'NodeImage'
   }
-  autoScalerProfile: {
+  autoScalerProfile: enableNodeAutoProvisioning ? null : {
     'daemonset-eviction-for-occupied-nodes': true
     'max-node-provision-time': '15m'
     'scale-down-delay-after-add': '10m'
   }
+  nodeProvisioningProfile: enableNodeAutoProvisioning
+    ? {
+        mode: 'Auto'
+        defaultNodePools: 'None'
+      }
+    : {
+        mode: 'Manual'
+      }
   networkProfile: {
     // Azure CNI overlay with Cilium dataplane
     networkPlugin: 'azure'
@@ -168,9 +178,10 @@ var aksBaseSpecificProperties = {
       ]
       vnetSubnetID: aksSubnetId
       orchestratorVersion: kubernetesVersion
-      enableAutoScaling: true
-      minCount: 1
-      maxCount: 3
+      enableAutoScaling: !enableNodeAutoProvisioning
+      count: enableNodeAutoProvisioning ? 2 : null
+      minCount: enableNodeAutoProvisioning ? null : 1
+      maxCount: enableNodeAutoProvisioning ? null : 3
       // Blue-green upgrade strategy for safer node OS auto-upgrades.
       upgradeStrategy: 'BlueGreen'
       upgradeSettingsBlueGreen: {

--- a/infra/modules/azmonitor/aks-diagnostics.bicep
+++ b/infra/modules/azmonitor/aks-diagnostics.bicep
@@ -44,6 +44,10 @@ resource diagnosticSetting 'Microsoft.Insights/diagnosticSettings@2021-05-01-pre
         enabled: true
       }
       {
+        category: 'karpenter-events'
+        enabled: true
+      }
+      {
         category: 'cloud-controller-manager'
         enabled: true
       }

--- a/k8s/apps/chaos-app/deployment.yaml
+++ b/k8s/apps/chaos-app/deployment.yaml
@@ -107,4 +107,5 @@ spec:
             timeoutSeconds: 3
             failureThreshold: 5
       nodeSelector:
+        kubernetes.io/arch: arm64
         kubernetes.io/os: linux

--- a/k8s/node-provisioning/aks-node-class.yaml
+++ b/k8s/node-provisioning/aks-node-class.yaml
@@ -1,0 +1,7 @@
+apiVersion: karpenter.azure.com/v1beta1
+kind: AKSNodeClass
+metadata:
+  name: chaos-arm64
+spec:
+  imageFamily: Ubuntu
+  osDiskSizeGB: 100

--- a/k8s/node-provisioning/kustomization.yaml
+++ b/k8s/node-provisioning/kustomization.yaml
@@ -1,0 +1,5 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - aks-node-class.yaml
+  - node-pool.yaml

--- a/k8s/node-provisioning/node-pool.yaml
+++ b/k8s/node-provisioning/node-pool.yaml
@@ -1,0 +1,41 @@
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: chaos-arm64
+spec:
+  template:
+    spec:
+      nodeClassRef:
+        group: karpenter.azure.com
+        kind: AKSNodeClass
+        name: chaos-arm64
+      expireAfter: Never
+      requirements:
+        - key: kubernetes.io/arch
+          operator: In
+          values: [arm64]
+        - key: kubernetes.io/os
+          operator: In
+          values: [linux]
+        - key: karpenter.azure.com/sku-name
+          operator: In
+          values:
+            - Standard_D4pds_v6
+            - Standard_D4pds_v5
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: [on-demand]
+        - key: karpenter.azure.com/sku-storage-ephemeralos-maxsize
+          operator: Gt
+          values: ["99"]
+      startupTaints:
+        - key: node.cilium.io/agent-not-ready
+          value: "true"
+          effect: NoExecute
+  disruption:
+    consolidationPolicy: WhenEmpty
+    consolidateAfter: 10m
+    budgets:
+      - nodes: "1"
+  limits:
+    cpu: "8"


### PR DESCRIPTION
AKS needs additional allocation resilience in Japan East while preserving Arm64 workloads and Ephemeral OS Disk. A single Virtual Machines multi-SKU pool cannot combine the selected v5 and v6 SKUs because their ephemeral disk placements differ, so this change adopts Node Auto Provisioning (NAP) for user capacity while retaining the existing fixed System pool.

## Approach

- Add a guarded `AZURE_AKS_ENABLE_NODE_AUTO_PROVISIONING` configuration path.
- Keep the two-node Arm64 Ephemeral System pool fixed and disable its Cluster Autoscaler when NAP is enabled.
- Configure AKS with `nodeProvisioningProfile.mode=Auto` and `defaultNodePools=None`.
- Add an Arm64, on-demand NodePool for `Standard_D4pds_v5` and `Standard_D4pds_v6` with an AKSNodeClass requiring more than 99 GiB of ephemeral storage.
- Limit initial NAP capacity to 8 CPUs and use `WhenEmpty`, a 10-minute consolidation delay, no expiration, and a one-node disruption budget.
- Add deployment, validation, rollback, and observability guidance, and record the accepted decision in ADR-018.

## Validation

- Built the Bicep deployment through the repository pre-commit hook.
- Validated in `eval` that NAP can provision both Arm64 SKU generations with 100 GiB Ephemeral OS Disk using their respective CacheDisk and NvmeDisk placements.
- Confirmed required node services, Redis and Workload Identity access, telemetry after collector readiness, Chaos Mesh recovery, scale-down to zero, and rollback to Manual mode with Cluster Autoscaler restored.

## Review notes

NAP improves the available user-capacity choices but does not guarantee SKU selection order or retry to another SKU or zone after `AllocationFailed`. It also does not change the allocation behavior of the fixed System AgentPool. The custom NodePool resources remain an explicit deployment step rather than being applied automatically by the normal `azd up` path.