### PR TITLE
feat: AKSの可観測性収集を改善

### DIFF
--- a/.github/skills/bicep-what-if-analysis/scripts/patterns/pattern_stats.json
+++ b/.github/skills/bicep-what-if-analysis/scripts/patterns/pattern_stats.json
@@ -1,39 +1,39 @@
 {
   "patterns": {
     "Microsoft.Network/virtualNetworks:custom_patterns:^subnets\\..*\\.properties\\.networkSecurityGroup$": {
-      "matchCount": 43,
+      "matchCount": 44,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^identityProfile$": {
-      "matchCount": 46,
+      "matchCount": 47,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.powerState$": {
-      "matchCount": 46,
+      "matchCount": 47,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^aadProfile\\.tenantID$": {
-      "matchCount": 46,
+      "matchCount": 47,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.Network/publicIPAddresses:auto_managed_patterns:^ddosSettings$": {
-      "matchCount": 46,
+      "matchCount": 47,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^servicePrincipalProfile$": {
-      "matchCount": 46,
+      "matchCount": 47,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^controlPlanePluginProfiles$": {
-      "matchCount": 46,
+      "matchCount": 47,
       "firstMatched": "2026-01-28T07:25:06.991920+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^ingressProfile\\.webAppRouting\\.nginx$": {
       "matchCount": 35,
@@ -46,34 +46,34 @@
       "lastMatched": "2026-08-06T09:14:49.994841+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^networkProfile\\.advancedNetworking\\.security\\.transitEncryption$": {
-      "matchCount": 45,
+      "matchCount": 46,
       "firstMatched": "2026-01-28T07:27:16.893220+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.ContainerService/managedClusters:custom_patterns:^agentPoolProfiles\\[\\d+\\]\\.orchestratorVersion$": {
-      "matchCount": 44,
+      "matchCount": 45,
       "firstMatched": "2026-01-28T07:27:16.893220+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^networkProfile\\.podCidrs$": {
-      "matchCount": 45,
+      "matchCount": 46,
       "firstMatched": "2026-01-28T07:27:16.893220+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^networkProfile\\.serviceCidrs$": {
-      "matchCount": 45,
+      "matchCount": 46,
       "firstMatched": "2026-01-28T07:27:16.893220+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.osDiskSizeGB$": {
-      "matchCount": 41,
+      "matchCount": 42,
       "firstMatched": "2026-01-28T07:36:35.396763+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.upgradeSettings$": {
-      "matchCount": 41,
+      "matchCount": 42,
       "firstMatched": "2026-01-28T07:36:35.396763+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.osSKU$": {
       "matchCount": 30,
@@ -81,29 +81,29 @@
       "lastMatched": "2026-03-18T04:33:16.070546+00:00"
     },
     "Microsoft.ContainerRegistry/registries:auto_managed_patterns:^roleAssignmentMode$": {
-      "matchCount": 41,
+      "matchCount": 42,
       "firstMatched": "2026-01-28T07:36:35.396763+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.securityProfile$": {
-      "matchCount": 41,
+      "matchCount": 42,
       "firstMatched": "2026-01-28T07:36:35.396763+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.osDiskType$": {
-      "matchCount": 41,
+      "matchCount": 42,
       "firstMatched": "2026-01-28T07:36:35.396763+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^autoScalerProfile\\.skip-nodes-with-local-storage$": {
-      "matchCount": 41,
+      "matchCount": 42,
       "firstMatched": "2026-01-28T07:36:35.396763+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^securityProfile\\.defender$": {
-      "matchCount": 40,
+      "matchCount": 41,
       "firstMatched": "2026-01-28T07:40:32.040732+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.count$": {
       "matchCount": 39,
@@ -111,9 +111,9 @@
       "lastMatched": "2026-08-06T09:14:49.994841+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^storageProfile$": {
-      "matchCount": 40,
+      "matchCount": 41,
       "firstMatched": "2026-01-28T07:40:32.040732+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^addonProfiles$": {
       "matchCount": 37,
@@ -121,44 +121,44 @@
       "lastMatched": "2026-05-18T23:19:10.964598+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^securityProfile\\.imageCleaner$": {
-      "matchCount": 32,
+      "matchCount": 33,
       "firstMatched": "2026-01-28T07:40:32.040732+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.Network/virtualNetworks:auto_managed_patterns:^privateEndpointVNetPolicies$": {
-      "matchCount": 40,
+      "matchCount": 41,
       "firstMatched": "2026-01-28T07:40:32.040732+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^windowsProfile$": {
-      "matchCount": 40,
+      "matchCount": 41,
       "firstMatched": "2026-01-28T07:40:32.040732+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^serviceMeshProfile$": {
-      "matchCount": 31,
+      "matchCount": 32,
       "firstMatched": "2026-02-02T09:46:15.864264+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.ContainerRegistry/registries:auto_managed_patterns:^networkRuleBypassAllowedForTasks$": {
-      "matchCount": 28,
+      "matchCount": 29,
       "firstMatched": "2026-03-04T00:59:09.421623+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.Network/publicIPAddresses:auto_managed_patterns:^ipTags$": {
-      "matchCount": 18,
+      "matchCount": 19,
       "firstMatched": "2026-03-04T00:59:09.421623+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.Network/virtualNetworks/subnets/providers/roleAssignments:auto_managed_patterns:^principalId$": {
-      "matchCount": 27,
+      "matchCount": 28,
       "firstMatched": "2026-03-04T01:01:54.287895+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.Network/virtualNetworks/subnets/providers/roleAssignments:auto_managed_patterns:^principalType$": {
-      "matchCount": 27,
+      "matchCount": 28,
       "firstMatched": "2026-03-04T01:01:54.287895+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.ContainerService/managedClusters:custom_patterns:^kubernetesVersion$": {
       "matchCount": 9,
@@ -166,9 +166,9 @@
       "lastMatched": "2026-05-18T23:19:10.964598+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^networkProfile\\.advancedNetworking\\.performance$": {
-      "matchCount": 12,
+      "matchCount": 13,
       "firstMatched": "2026-03-18T04:33:16.070546+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.upgradeSettingsBlueGreen$": {
       "matchCount": 1,
@@ -176,14 +176,14 @@
       "lastMatched": "2026-03-18T04:33:16.070546+00:00"
     },
     "Microsoft.Chaos/experiments:auto_managed_patterns:^tags$": {
-      "matchCount": 12,
+      "matchCount": 13,
       "firstMatched": "2026-03-18T04:33:16.070546+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.Chaos/experiments:auto_managed_patterns:^steps\\.\\d+\\.branches\\.\\d+\\.actions\\.\\d+\\.parameters\\.\\d+\\.value$": {
-      "matchCount": 12,
+      "matchCount": 13,
       "firstMatched": "2026-03-18T04:33:16.070546+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^agentPoolProfiles\\.\\d+\\.upgradeStrategy$": {
       "matchCount": 1,
@@ -191,179 +191,179 @@
       "lastMatched": "2026-03-18T04:33:16.070546+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^ingressProfile\\.webAppRouting\\.defaultDomain$": {
-      "matchCount": 12,
+      "matchCount": 13,
       "firstMatched": "2026-03-18T04:33:16.070546+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^nodeDisruptionProfile$": {
-      "matchCount": 8,
+      "matchCount": 9,
       "firstMatched": "2026-05-18T23:06:29.633543+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.OperationalInsights/workspaces/tables:auto_managed_patterns:^retentionInDays$": {
-      "matchCount": 8,
+      "matchCount": 9,
       "firstMatched": "2026-05-18T23:06:29.633543+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.OperationalInsights/workspaces/tables:auto_managed_patterns:^totalRetentionInDays$": {
-      "matchCount": 8,
+      "matchCount": 9,
       "firstMatched": "2026-05-18T23:06:29.633543+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.ContainerService/fleets/autoUpgradeProfiles:auto_managed_patterns:^longTermSupport$": {
-      "matchCount": 8,
+      "matchCount": 9,
       "firstMatched": "2026-05-18T23:06:29.633543+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.ContainerService/fleets/members:auto_managed_patterns:^labels$": {
-      "matchCount": 8,
+      "matchCount": 9,
       "firstMatched": "2026-05-18T23:06:29.633543+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.Cache/redisEnterprise/databases:auto_managed_patterns:^redisVersion$": {
-      "matchCount": 8,
+      "matchCount": 9,
       "firstMatched": "2026-05-18T23:06:29.633543+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^healthMonitorProfile$": {
-      "matchCount": 8,
+      "matchCount": 9,
       "firstMatched": "2026-05-18T23:06:29.633543+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.ContainerService/fleets/updateStrategies:auto_managed_patterns:^strategy\\.stages\\.\\d+\\.afterStageWaitInSeconds$": {
-      "matchCount": 8,
+      "matchCount": 9,
       "firstMatched": "2026-05-18T23:06:29.633543+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^azureMonitorProfile\\.metrics\\.controlPlane$": {
-      "matchCount": 5,
+      "matchCount": 6,
       "firstMatched": "2026-05-18T23:06:29.633543+00:00",
-      "lastMatched": "2026-05-18T23:19:10.964598+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.Network/privateDnsZones/virtualNetworkLinks:auto_managed_patterns:^resolutionPolicy$": {
-      "matchCount": 8,
+      "matchCount": 9,
       "firstMatched": "2026-05-18T23:06:29.633543+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.Authorization/roleAssignments:auto_managed_patterns:^principalType$": {
-      "matchCount": 7,
+      "matchCount": 8,
       "firstMatched": "2026-05-18T23:11:17.563406+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.Authorization/roleAssignments:auto_managed_patterns:^principalId$": {
-      "matchCount": 7,
+      "matchCount": 8,
       "firstMatched": "2026-05-18T23:11:17.563406+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.Insights/scheduledQueryRules:auto_managed_patterns:^windowSize$": {
-      "matchCount": 6,
+      "matchCount": 7,
       "firstMatched": "2026-05-18T23:13:14.888125+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.ContainerService/managedClusters/providers/diagnosticSettings:auto_managed_patterns:^metrics$": {
-      "matchCount": 5,
+      "matchCount": 6,
       "firstMatched": "2026-05-18T23:15:22.306674+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.ContainerService/managedClusters/providers/diagnosticSettings:auto_managed_patterns:^logs\\.\\d+$": {
-      "matchCount": 5,
+      "matchCount": 6,
       "firstMatched": "2026-05-18T23:15:22.306674+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.ContainerService/managedClusters/providers/diagnosticSettings:auto_managed_patterns:^logs\\.\\d+\\.retentionPolicy\\.days$": {
-      "matchCount": 5,
+      "matchCount": 6,
       "firstMatched": "2026-05-18T23:15:22.306674+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.ContainerService/managedClusters/providers/dataCollectionRuleAssociations:auto_managed_patterns:^dataCollectionRuleId$": {
-      "matchCount": 5,
+      "matchCount": 6,
       "firstMatched": "2026-05-18T23:15:22.306674+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.Monitor/accounts/providers/roleAssignments:auto_managed_patterns:^principalId$": {
-      "matchCount": 3,
+      "matchCount": 4,
       "firstMatched": "2026-08-06T08:49:48.172598+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.Monitor/accounts/providers/roleAssignments:auto_managed_patterns:^principalType$": {
-      "matchCount": 3,
+      "matchCount": 4,
       "firstMatched": "2026-08-06T08:49:48.172598+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.Insights/dataCollectionRules/providers/roleAssignments:auto_managed_patterns:^principalId$": {
-      "matchCount": 3,
+      "matchCount": 4,
       "firstMatched": "2026-08-06T08:49:48.172598+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^hostedSystemProfile$": {
-      "matchCount": 3,
+      "matchCount": 4,
       "firstMatched": "2026-08-06T08:49:48.172598+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.ContainerService/managedClusters/providers/extensions:auto_managed_patterns:^aksAssignedIdentity$": {
-      "matchCount": 3,
+      "matchCount": 4,
       "firstMatched": "2026-08-06T08:49:48.172598+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.ContainerService/managedClusters/providers/extensions:custom_patterns:^scope$": {
-      "matchCount": 3,
+      "matchCount": 4,
       "firstMatched": "2026-08-06T08:49:48.172598+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^addonProfiles\\.omsagent$": {
-      "matchCount": 3,
+      "matchCount": 4,
       "firstMatched": "2026-08-06T08:49:48.172598+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.Insights/dataCollectionRules/providers/roleAssignments:auto_managed_patterns:^principalType$": {
-      "matchCount": 3,
+      "matchCount": 4,
       "firstMatched": "2026-08-06T08:49:48.172598+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.Storage/storageAccounts/providers/roleAssignments:auto_managed_patterns:^principalId$": {
-      "matchCount": 3,
+      "matchCount": 4,
       "firstMatched": "2026-08-06T08:49:48.172598+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.Storage/storageAccounts/blobServices/containers:auto_managed_patterns:^defaultEncryptionScope$": {
-      "matchCount": 3,
+      "matchCount": 4,
       "firstMatched": "2026-08-06T08:49:48.172598+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.ContainerService/managedClusters/providers/extensions:auto_managed_patterns:^managementDetails$": {
-      "matchCount": 3,
+      "matchCount": 4,
       "firstMatched": "2026-08-06T08:49:48.172598+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^ingressProfile\\.webAppRouting\\.nginx\\.mode$": {
-      "matchCount": 3,
+      "matchCount": 4,
       "firstMatched": "2026-08-06T08:49:48.172598+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.Storage/storageAccounts/blobServices/containers:auto_managed_patterns:^denyEncryptionScopeOverride$": {
-      "matchCount": 3,
+      "matchCount": 4,
       "firstMatched": "2026-08-06T08:49:48.172598+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.Storage/storageAccounts/blobServices:auto_managed_patterns:^properties$": {
-      "matchCount": 3,
+      "matchCount": 4,
       "firstMatched": "2026-08-06T08:49:48.172598+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.ContainerService/managedClusters/providers/extensions:auto_managed_patterns:^extensionState$": {
-      "matchCount": 3,
+      "matchCount": 4,
       "firstMatched": "2026-08-06T08:49:48.172598+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.ContainerService/managedClusters:auto_managed_patterns:^addonProfiles\\.extensionManager$": {
-      "matchCount": 3,
+      "matchCount": 4,
       "firstMatched": "2026-08-06T08:49:48.172598+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.Storage/storageAccounts/providers/roleAssignments:auto_managed_patterns:^principalType$": {
-      "matchCount": 3,
+      "matchCount": 4,
       "firstMatched": "2026-08-06T08:49:48.172598+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     },
     "Microsoft.Management/serviceGroups/providers/slis:custom_patterns:^sliProperties\\.(goodSignals|totalSignals)\\.signalSources\\.\\d+\\.temporalAggregation\\.windowSizeMinutes$": {
       "matchCount": 1,
@@ -371,10 +371,10 @@
       "lastMatched": "2026-08-06T08:50:08.427862+00:00"
     },
     "Microsoft.ContainerService/managedClusters/providers/extensions:custom_patterns:^autoUpgradeMode$": {
-      "matchCount": 2,
+      "matchCount": 3,
       "firstMatched": "2026-08-06T09:14:49.994841+00:00",
-      "lastMatched": "2026-08-21T04:34:47.827444+00:00"
+      "lastMatched": "2026-08-21T09:01:03.469826+00:00"
     }
   },
-  "lastRun": "2026-08-21T04:34:47.827444+00:00"
+  "lastRun": "2026-08-21T09:01:03.469826+00:00"
 }

--- a/docs/adr/006-otlp-vendor-neutral-otel.md
+++ b/docs/adr/006-otlp-vendor-neutral-otel.md
@@ -28,4 +28,5 @@ AKS App Monitoring は、OTLP/HTTP で受け取った traces、metrics、logs �
 - App Insights 直接 egress ルールは不要になり、CiliumNetworkPolicy は AKS OTel Collector Pod 宛に整理できる。
 - AKS App Monitoring の OTLP 経路は preview のため、破壊的変更の可能性をラボ環境の制約として受け入れる。
 - OTLP 対応 App Insights と Azure Monitor Workspace は Azure 管理の resource group を作る。命名や削除順序の制約は [docs/workarounds.md](../workarounds.md#b-otlp--application-insights-関連-adr-006) と [docs/deployment.md](../deployment.md) に記録する。
+- chaos-app の request telemetry の保存先と診断方法は [docs/observability.md](../observability.md#アプリケーション-trace-と-request-telemetry) に置く。
 - OTLP logs の対象、Python OpenTelemetry Logs SDK の成熟度、ContainerLogV2 との使い分けは [docs/observability.md](../observability.md#otlp-logs) に置く。

--- a/docs/adr/012-functions-direct-external-sli-probe.md
+++ b/docs/adr/012-functions-direct-external-sli-probe.md
@@ -19,14 +19,14 @@ ADR-011 では、AKS クラスタ停止時も SLI を悪化させるため、App
 - Function host / Timer 停止で欠落した window は、過去状態を再プローブできないため bad (`0/1`) として発行する。`externalSliMaxCatchupWindows` を上限にし、Azure Monitor Workspace の `OldData` 制約を避けるため、catch-up 分は publisher 実行時刻の sample に合算する。
 - Metric names は ADR-011 と同じ `chaos_app_external_availability_good/total`, `chaos_app_external_latency_good/total`, `chaos_app_external_sli_publisher_heartbeat` を維持する。Prometheus label key も `environment`, `service`, `test` を維持し、`test` には probe name を入れる。
 - Probe name の既定値は旧 availability test name と同じ `avail-${appName}-${environment}-${resourceToken}` 形にし、既存 SLI dimension の連続性を保つ。
-- Function App では Azure Monitor OpenTelemetry を構成し、probe HTTP 呼び出しを client span として記録する。Probe は trace context を伝搬し、chaos-app 側の `GET /` request telemetry と相関させる。Application Map の Function App -> chaos app の線は診断用であり、SLI の正本は Managed Prometheus に発行する good / total metrics とする。
+- Function App では Azure Monitor OpenTelemetry を構成し、probe HTTP 呼び出しを client span として記録する。Probe は trace context を伝搬し、chaos-app 側の `GET /` Server span と `TraceId` で相関させる。SLI の正本は Managed Prometheus に発行する good / total metrics とする。
 - Function App の Application Insights role name は生成ホスト名ではなく `external-sli-publisher` とし、Functions host は `telemetryMode: OpenTelemetry` と `OTEL_SERVICE_NAME`、Python worker は `service.name` resource attribute で揃える。環境差分は role instance 側で識別する。
 - Publisher の Function host storage と deployment storage は managed identity 接続を維持し、public access は無効化する。Prometheus remote-write に必要な `Monitoring Metrics Publisher` RBAC は維持し、Log Analytics Reader RBAC は不要化する。
 
 ## Consequences
 
 - **利点**: Application Insights availability test と Log Analytics query への依存がなくなり、外形 SLI source の構成要素が減る。
-- **利点**: Function App から chaos app への HTTP dependency telemetry が Application Insights / Application Map に表示され、外形 probe 経路を視覚的に確認できる。
+- **利点**: Function App の HTTP dependency と chaos-app の Server span を `TraceId` で相関できる。診断方法は [可観測性ガイド](../observability.md#アプリケーション-trace-と-request-telemetry) に置く。
 - **利点**: AKS 内 synthetic traffic に依存しないため、AKS クラスタ停止時も SLI が bad sample を受け取れる。
 - **制約**: Microsoft managed availability test の multi-location 実行は使わない。外形 source の冗長性は Function App の実行基盤に依存する。
 - **制約**: Function host / Timer 停止中のサービス状態は再構成できないため、欠損 window は保守的に bad として扱う。これは service 停止と probe source 停止を SLI 上で同じ低下として表現する。
@@ -40,7 +40,7 @@ ADR-011 では、AKS クラスタ停止時も SLI を悪化させるため、App
 
 ### 案 B: Application Insights dependency telemetry を直接 SLI の正本にする
 
-- 不採用理由: Azure Monitor SLI の input signal は Managed Prometheus metrics であり、Application Insights dependencies を直接 input signal にできない。dependency telemetry は Application Map と診断に使い、SLI input は Prometheus good / total metrics にする。
+- 不採用理由: Azure Monitor SLI の input signal は Managed Prometheus metrics であり、Application Insights dependencies を直接 input signal にできない。dependency telemetry は診断に使い、SLI input は Prometheus good / total metrics にする。
 
 ### 案 C: AKS 内 CronJob synthetic traffic に戻す
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -241,57 +241,16 @@ PowerShellでは `$env:UV_NO_SYNC = "1"` を設定します。
 docker build -f src/api/Dockerfile -t aks-chaos-lab:local .
 ```
 
-組織承認済みpackage indexが必要な管理対象環境では、ローカルbuildに限りuser-level `uv.toml`をBuildKit secretとして渡します。このsecretを公開CIへ渡してはいけません。
-
-次のPOSIX shell例は、API imageをローカルに作成します。
-
-```bash
-UV_CONFIG_PATH="$HOME/.config/uv/uv.toml"
-UV_INDEX_CONFIG_SHA256="$(
-  uv run --no-project "${PWD}/scripts/approved_index_config.py" digest "$UV_CONFIG_PATH"
-)"
-docker build \
-  --build-arg UV_INDEX_MODE=approved-index \
-  --build-arg UV_INDEX_CONFIG_SHA256="$UV_INDEX_CONFIG_SHA256" \
-  --secret id=uv-config,src="$UV_CONFIG_PATH" \
-  -f src/api/Dockerfile \
-  -t aks-chaos-lab:local .
-```
-
-PowerShellでは、次を実行します。
-
-```powershell
-$UvConfigPath = Join-Path $env:APPDATA "uv\uv.toml"
-$ApprovedIndexConfigScript = Join-Path $PWD "scripts\approved_index_config.py"
-$UvIndexConfigSha256 = uv run --no-project `
-  $ApprovedIndexConfigScript digest $UvConfigPath
-docker build `
-  --build-arg "UV_INDEX_MODE=approved-index" `
-  --build-arg "UV_INDEX_CONFIG_SHA256=$UvIndexConfigSha256" `
-  --secret "id=uv-config,src=$UvConfigPath" `
-  -f src/api/Dockerfile `
-  -t aks-chaos-lab:local .
-```
-
-管理対象環境からAKSへdeployする場合は、対象のazd environmentを選択し、OpenTelemetry instrumentationを適用してから、作成済みimageを`--from-package`へ渡します。
+組織承認済みpackage indexが必要な環境では、専用taskでAPI imageをbuildし、そのimageを`azd deploy --from-package`へ渡します。taskはuser-level `uv.toml`を検証し、BuildKit secretとしてbuildへ渡します。
 
 ```bash
 azd env select <environment>
+uv run --no-project "${PWD}/scripts/tasks.py" package-api-approved-index
 azd deploy api-instrumentation --no-prompt
-azd deploy api --from-package aks-chaos-lab:local --no-prompt
+uv run --no-project "${PWD}/scripts/tasks.py" deploy-api-approved-index
 ```
 
-PowerShellでは、次を実行します。
-
-```powershell
-azd env select <environment>
-azd deploy api-instrumentation --no-prompt
-azd deploy api --from-package aks-chaos-lab:local --no-prompt
-```
-
-`azd deploy api`を`--from-package`なしで実行すると、azdはDocker imageを再buildします。現在の`azure.yaml`はBuildKit secretをazdのbuildへ渡さないため、そのbuildはpublic PyPIを使用します。管理対象環境では、approved indexで作成したローカルimageを`--from-package`で指定してください。
-
-configのSHA-256はdependency layerとcache mountのkeyになります。Dockerfileはmountしたconfigのhashを照合するため、configを変更すると古いlayerを再利用しません。build logを共有する前に、index URLや認証情報が含まれていないことを確認してください。
+通常の`azd package api`と`azd deploy api`はpublic PyPIを使用します。認証が必要なindexは専用taskの対象外です。`uv.lock`はpublic PyPIのURLを維持します。
 
 ### public lockfile の更新
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -16,6 +16,34 @@
 
 Grafana ダッシュボードは Azure Portal の対象 AKS > Monitoring > Dashboards with Grafana から参照できます。
 
+## AKS control plane metrics
+
+AKS control plane metrics は `azureMonitorProfile.metrics.controlPlane.enabled` で有効化し、Managed Prometheus へ API server と etcd の metric を収集します。minimal ingestion profile の収集対象は Microsoft Learn の [Minimal ingestion profile for control plane Metrics in Managed Prometheus](https://learn.microsoft.com/azure/aks/monitor-aks-reference#minimal-ingestion-profile-for-control-plane-metrics-in-managed-prometheus) を参照してください。
+
+## DNS と network observability
+
+クラスタ全体の DNS 量には CoreDNS の `coredns_dns_requests_total` を使います。`ama-metrics-settings-configmap` は schema v2 で cluster metrics と control-plane metrics を分離し、CoreDNS default target を 30 秒間隔、minimal ingestion 有効で収集します。
+
+ACNS の DNS dashboard は `hubble_dns_queries_total` と `hubble_dns_responses_total` を使います。Cilium cluster では DNS rule を持つ CiliumNetworkPolicy の対象だけが DNS visibility に含まれるため、Hubble DNS metric をクラスタ全体の DNS 量として扱いません。
+
+Drops (Workload) dashboard は `rate(hubble_drop_total[...])` と `> 0` を使います。drop がない期間は No data となり、Heatmap は TypeError を表示する場合があります。counter が最初の drop 発生時に作られ、事前の 0 sample がない場合、その初回増分は後から `rate()` で復元できません。収集停止の確認には、対象 workload の表示だけでなく、`networkobservability-hubble` target とクラスタ全体の `hubble_drop_total` の増加を確認してください。
+
+## アプリケーション trace と request telemetry
+
+chaos-appのHTTP requestは、[ADR-006](adr/006-otlp-vendor-neutral-otel.md)のvendor-neutral OTLP経路により`OTelSpans`へ保存されます。診断には`ServiceName == "chaos-app"`かつ`Kind == "Server"`のspanを使います。
+
+```kusto
+OTelSpans
+| where TimeGenerated > ago(30m)
+| where ServiceName == "chaos-app" and Kind == "Server"
+| project TimeGenerated, Name, ResultCode, Success, DurationMs, TraceId, SpanId, ParentSpanId
+| order by TimeGenerated desc
+```
+
+external-sli-publisherはclassic ingestionを使用するため、`AppRequests`と`AppDependencies`を使います。両経路の相関にはKQLと`TraceId`を使用します。`AppRequests`が必須になった場合はADR-006を再検討します。
+
+native OTLP ingestionはpreviewです。制約は[OpenTelemetry configuration options](https://learn.microsoft.com/azure/azure-monitor/containers/opentelemetry-options)を確認します。
+
 ## アプリ信頼性 signal
 
 Azure Monitor SLI の Availability / Latency は、AKS 外で動作する Azure Functions external SLI publisher の `GET /` probe を正本にします。
@@ -62,7 +90,7 @@ Cilium L7 policy で許可する path は以下に限定します。
 | `GET /readyz` | readiness | あり | Kubernetes probe |
 | `GET /metrics` | Prometheus scrape | なし | Managed Prometheus |
 
-外部 Gateway 経由では component が `GET /` を許可し、`chaos-app` 固有 patch が `GET /health` を追加します。Azure Functions external SLI publisher は通常 API の `GET /` を probe し、trace context を伝搬して Application Map で Function App から chaos-app への依存関係を表示します。`/livez`、`/readyz`、`/metrics` は内部 source のみに許可します。probe を追加する場合は、アプリ route、Kubernetes probe、CNP テンプレートまたは app 固有 patch を同時に更新してください。
+外部 Gateway 経由では component が `GET /` を許可し、`chaos-app` 固有 patch が `GET /health` を追加します。Azure Functions external SLI publisher は通常 API の `GET /` を probe し、trace context を伝搬します。Function dependency と chaos-app Server span は `TraceId` で KQL 相関できますが、Application Map が classic table と OTel table を跨いで表示することは保証しません。`/livez`、`/readyz`、`/metrics` は内部 source のみに許可します。probe を追加する場合は、アプリ route、Kubernetes probe、CNP テンプレートまたは app 固有 patch を同時に更新してください。
 
 ## 外形 SLI publisher
 

--- a/infra/modules/aks.bicep
+++ b/infra/modules/aks.bicep
@@ -60,6 +60,9 @@ var aksCommonProperties = {
     }
     metrics: {
       enabled: true
+      controlPlane: {
+        enabled: true
+      }
       kubeStateMetrics: {
         metricAnnotationsAllowList: ''
         metricLabelsAllowlist: ''

--- a/k8s/observability/ama-metrics-settings-configmap.yaml
+++ b/k8s/observability/ama-metrics-settings-configmap.yaml
@@ -3,89 +3,103 @@ apiVersion: v1
 data:
   schema-version:
     #string.used by agent to parse config. supported versions are {v1, v2}. Configs with other schema versions will be rejected by the agent.
-    v1
+    v2
   config-version:
     #string.used by customer to keep track of this config file's version in their source control/repository (max allowed 10 chars, other chars will be truncated)
     ver1
+  cluster-metrics: |-
+    default-targets-scrape-enabled: |-
+      kubelet = true
+      coredns = true
+      cadvisor = true
+      kubeproxy = false
+      apiserver = false
+      kubestate = true
+      nodeexporter = true
+      windowsexporter = false
+      windowskubeproxy = false
+      kappiebasic = true
+      networkobservabilityRetina = true
+      networkobservabilityHubble = true
+      networkobservabilityCilium = true
+      acstor-capacity-provisioner = true
+      acstor-metrics-exporter = true
+      local-csi-driver = true
+      ztunnel = false
+      istio-cni = false
+      dcgmexporter = false
+      prometheuscollectorhealth = false
+    pod-annotation-based-scraping: |-
+      podannotationnamespaceregex = ".*"
+    default-targets-metrics-keep-list: |-
+      kubelet = ""
+      coredns = ""
+      cadvisor = ""
+      kubeproxy = ""
+      apiserver = ""
+      kubestate = ""
+      nodeexporter = ""
+      windowsexporter = ""
+      windowskubeproxy = ""
+      podannotations = "envoy_cluster_upstream_rq|envoy_cluster_upstream_rq_completed|envoy_cluster_upstream_rq_total|envoy_cluster_external_upstream_rq|envoy_cluster_external_upstream_rq_time_bucket|envoy_cluster_external_upstream_rq_time_sum|envoy_cluster_external_upstream_rq_time_count|envoy_cluster_upstream_cx_total"
+      kappiebasic = ""
+      networkobservabilityRetina = ""
+      networkobservabilityHubble = "hubble.*"
+      networkobservabilityCilium = ""
+      acstor-capacity-provisioner = ""
+      acstor-metrics-exporter = ""
+      local-csi-driver = ""
+      ztunnel = ""
+      istio-cni = ""
+      dcgmexporter = ""
+    minimal-ingestion-profile: |-
+      enabled = true
+    default-targets-scrape-interval-settings: |-
+      kubelet = "30s"
+      coredns = "30s"
+      cadvisor = "30s"
+      kubeproxy = "30s"
+      apiserver = "30s"
+      kubestate = "30s"
+      nodeexporter = "30s"
+      windowsexporter = "30s"
+      windowskubeproxy = "30s"
+      kappiebasic = "30s"
+      networkobservabilityRetina = "30s"
+      networkobservabilityHubble = "30s"
+      networkobservabilityCilium = "30s"
+      acstor-capacity-provisioner = "30s"
+      acstor-metrics-exporter = "30s"
+      local-csi-driver = "30s"
+      ztunnel = "30s"
+      istio-cni = "30s"
+      dcgmexporter = "30s"
+      prometheuscollectorhealth = "30s"
+      podannotations = "30s"
+  controlplane-metrics: |-
+    default-targets-scrape-enabled: |-
+      apiserver = true
+      cluster-autoscaler = false
+      node-auto-provisioning = false
+      kube-scheduler = false
+      kube-controller-manager = false
+      etcd = true
+      istio = false
+    default-targets-metrics-keep-list: |-
+      apiserver = ""
+      cluster-autoscaler = ""
+      node-auto-provisioning = ""
+      kube-scheduler = ""
+      kube-controller-manager = ""
+      etcd = ""
+      istio = ""
+    minimal-ingestion-profile: |-
+      enabled = true
   prometheus-collector-settings: |-
     cluster_alias = ""
+    debug-mode = false
     https_config = true
-  default-scrape-settings-enabled: |-
-    kubelet = true
-    coredns = false
-    cadvisor = true
-    kubeproxy = false
-    apiserver = false
-    kubestate = true
-    nodeexporter = true
-    windowsexporter = false
-    windowskubeproxy = false
-    kappiebasic = true
-    networkobservabilityRetina = true
-    networkobservabilityHubble = true
-    networkobservabilityCilium = true
-    prometheuscollectorhealth = false
-    podannotations = true
-    controlplane-apiserver = true
-    controlplane-cluster-autoscaler = false
-    controlplane-node-auto-provisioning = false
-    controlplane-kube-scheduler = false
-    controlplane-kube-controller-manager = false
-    controlplane-etcd = true
-    acstor-capacity-provisioner = true
-    acstor-metrics-exporter = true
-    local-csi-driver = true
-  # Regex for which namespaces to scrape through pod annotation based scraping.
-  # This is none by default.
-  # Ex: Use 'namespace1|namespace2' to scrape the pods in the namespaces 'namespace1' and 'namespace2'.
-  pod-annotation-based-scraping: |-
-    podannotationnamespaceregex = ".*"
-  default-targets-metrics-keep-list: |-
-    kubelet = ""
-    coredns = ""
-    cadvisor = ""
-    kubeproxy = ""
-    apiserver = ""
-    kubestate = ""
-    nodeexporter = ""
-    windowsexporter = ""
-    windowskubeproxy = ""
-    podannotations = "envoy_cluster_upstream_rq|envoy_cluster_upstream_rq_completed|envoy_cluster_upstream_rq_total|envoy_cluster_external_upstream_rq|envoy_cluster_external_upstream_rq_time_bucket|envoy_cluster_external_upstream_rq_time_sum|envoy_cluster_external_upstream_rq_time_count|envoy_cluster_upstream_cx_total"
-    kappiebasic = ""
-    networkobservabilityRetina = ""
-    networkobservabilityHubble = "hubble.*"
-    networkobservabilityCilium = ""
-    controlplane-apiserver = ""
-    controlplane-cluster-autoscaler = ""
-    controlplane-node-auto-provisioning = ""
-    controlplane-kube-scheduler = ""
-    controlplane-kube-controller-manager = ""
-    controlplane-etcd = ""
-    acstor-capacity-provisioner = ""
-    acstor-metrics-exporter = ""
-    local-csi-driver = ""
-    minimalingestionprofile = true
-  default-targets-scrape-interval-settings: |-
-    kubelet = "30s"
-    coredns = "30s"
-    cadvisor = "30s"
-    kubeproxy = "30s"
-    apiserver = "30s"
-    kubestate = "30s"
-    nodeexporter = "30s"
-    windowsexporter = "30s"
-    windowskubeproxy = "30s"
-    kappiebasic = "30s"
-    networkobservabilityRetina = "30s"
-    networkobservabilityHubble = "30s"
-    networkobservabilityCilium = "30s"
-    prometheuscollectorhealth = "30s"
-    acstor-capacity-provisioner = "30s"
-    acstor-metrics-exporter = "30s"
-    local-csi-driver = "30s"
-    podannotations = "30s"
-  debug-mode: |-
-    enabled = false
+    secrets_access_namespaces = ""
 metadata:
   name: ama-metrics-settings-configmap
   namespace: kube-system

--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from approved_index_config import (
     UNSAFE_UV_ENVIRONMENT_VARIABLES,
     ApprovedIndexConfigError,
+    config_sha256,
     user_uv_config_path,
     validate_approved_index_config,
 )
@@ -42,6 +43,7 @@ KUBECONFORM_SKIP = "VerticalPodAutoscaler,CiliumNetworkPolicy,Kustomization,Gate
 APPROVED_INDEX_STATE_DIRECTORY = ".uv-state"
 APPROVED_INDEX_ENVIRONMENT_STATE_FILENAME = ".approved-index-sync.json"
 APPROVED_INDEX_STATE_VERSION = 3
+API_LOCAL_IMAGE = "aks-chaos-lab:local"
 
 
 def print_step(message: str) -> None:
@@ -931,6 +933,53 @@ def target_build() -> None:
     print_success("Docker image built")
 
 
+def target_package_api_approved_index() -> None:
+    print_step("Building the API image with the approved package index")
+    config_path = user_uv_config_path()
+    try:
+        validate_approved_index_config(config_path)
+    except ApprovedIndexConfigError as error:
+        print(f"error: {error}", file=sys.stderr)
+        raise SystemExit(1) from error
+
+    run(
+        [
+            "docker",
+            "build",
+            "--platform",
+            "linux/arm64",
+            "--build-arg",
+            "UV_INDEX_MODE=approved-index",
+            "--build-arg",
+            f"UV_INDEX_CONFIG_SHA256={config_sha256(config_path)}",
+            "--secret",
+            f"id=uv-config,src={config_path}",
+            "--file",
+            "src/api/Dockerfile",
+            "--tag",
+            API_LOCAL_IMAGE,
+            ".",
+        ],
+        cwd=ROOT,
+    )
+    print_success("API image built")
+
+
+def target_deploy_api_approved_index() -> None:
+    print_step("Deploying the prebuilt API image through azd")
+    run(
+        [
+            "azd",
+            "deploy",
+            "api",
+            "--from-package",
+            API_LOCAL_IMAGE,
+            "--no-prompt",
+        ],
+    )
+    print_success("API deployed")
+
+
 def target_run() -> None:
     print_step("Starting app on http://localhost:8000")
     run_uv_in(
@@ -1090,6 +1139,7 @@ TARGETS: dict[str, Callable[[], None]] = {
     "check-uv-version": target_check_uv_version,
     "clean": target_clean,
     "compile-aw": target_compile_aw,
+    "deploy-api-approved-index": target_deploy_api_approved_index,
     "format": target_format,
     "format-check": target_format_check,
     "help": target_help,
@@ -1103,6 +1153,7 @@ TARGETS: dict[str, Callable[[], None]] = {
     "load-smoke": target_load_smoke,
     "load-spike": target_load_spike,
     "load-stress": target_load_stress,
+    "package-api-approved-index": target_package_api_approved_index,
     "qa": target_qa,
     "qa-app": target_qa_app,
     "qa-platform": target_qa_platform,

--- a/scripts/tests/test_uv_workflow.py
+++ b/scripts/tests/test_uv_workflow.py
@@ -263,6 +263,54 @@ def test_child_environment_removes_unsafe_uv_overrides(
     assert environment["UV_INDEX_APPROVED_INDEX_USERNAME"] == "username"
 
 
+def test_package_api_approved_index_uses_buildkit_secret(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    config_path = tmp_path / "uv.toml"
+    write_approved_config(
+        config_path, "https://packagefeedproxy.microsoft.io/pypi/simple"
+    )
+    monkeypatch.setattr(tasks, "user_uv_config_path", lambda: config_path)
+    commands: list[list[str]] = []
+    monkeypatch.setattr(
+        tasks,
+        "run",
+        lambda command, **_kwargs: commands.append(command),
+    )
+
+    tasks.target_package_api_approved_index()
+
+    command = commands[0]
+    assert command[:3] == ["docker", "build", "--platform"]
+    assert f"id=uv-config,src={config_path}" in command
+    assert "UV_INDEX_MODE=approved-index" in command
+    assert tasks.API_LOCAL_IMAGE in command
+
+
+def test_deploy_api_approved_index_uses_prebuilt_image(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    commands: list[list[str]] = []
+    monkeypatch.setattr(
+        tasks,
+        "run",
+        lambda command, **_kwargs: commands.append(command),
+    )
+
+    tasks.target_deploy_api_approved_index()
+
+    assert commands == [
+        [
+            "azd",
+            "deploy",
+            "api",
+            "--from-package",
+            tasks.API_LOCAL_IMAGE,
+            "--no-prompt",
+        ]
+    ]
+
+
 def test_run_uv_binds_root_project_and_environment(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/src/api/Dockerfile
+++ b/src/api/Dockerfile
@@ -30,18 +30,25 @@ ARG UV_INDEX_MODE=public
 ARG UV_INDEX_CONFIG_SHA256=public
 RUN --mount=type=cache,id=uv-${UV_INDEX_MODE}-${UV_INDEX_CONFIG_SHA256},target=/root/.cache/uv \
     --mount=type=secret,id=uv-config,target=/root/.config/uv/uv.toml,required=false \
+    approved_index_path=; \
     case "$UV_INDEX_MODE" in \
       public) \
         test "$UV_INDEX_CONFIG_SHA256" = public \
         && test ! -e /root/.config/uv/uv.toml \
         ;; \
       approved-index) \
-        printf '%s  %s\n' "$UV_INDEX_CONFIG_SHA256" /root/.config/uv/uv.toml \
+        test -e /root/.config/uv/uv.toml \
+        && printf '%s  %s\n' "$UV_INDEX_CONFIG_SHA256" /root/.config/uv/uv.toml \
           | sha256sum -c - \
         && python scripts/approved_index_config.py /root/.config/uv/uv.toml \
+        && approved_index_path=/root/.config/uv/uv.toml \
         ;; \
-      *) echo "error: UV_INDEX_MODE must be public or approved-index" >&2; exit 1 ;; \
+      *) \
+        echo "error: UV_INDEX_MODE must be public or approved-index" >&2; \
+        exit 1 \
+        ;; \
     esac \
+    && if [ -n "$approved_index_path" ]; then export UV_CONFIG_FILE="$approved_index_path"; fi \
     && python scripts/public_lock.py lock pyproject.toml uv.lock \
     && uv export --quiet --frozen --package aks-chaos-lab-api --no-dev \
       --no-emit-workspace --no-emit-index-url \
@@ -50,7 +57,7 @@ RUN --mount=type=cache,id=uv-${UV_INDEX_MODE}-${UV_INDEX_CONFIG_SHA256},target=/
     && uv venv /app/.venv \
     && uv pip sync --require-hashes /tmp/requirements.txt \
       --python /app/.venv/bin/python --compile-bytecode \
-    && rm /tmp/requirements.txt
+    && rm -f /tmp/requirements.txt /tmp/uv.toml
 
 # Copy application code
 COPY src/api/app ./app


### PR DESCRIPTION
AKSのcontrol-plane metricsとクラスタ全体のDNS量をraw seriesで確認できるようにし、管理対象環境でpublic PyPIへの接続に依存せずAPI imageを再構築できるようにします。

## 変更内容

- AKSのcontrol-plane metricsを有効化し、AMA metrics ConfigMapをschema v2へ更新
- API server、etcd、CoreDNSの収集を有効化
- chaos-appのrequest telemetryは`AppRequests`ではなく`OTelSpans`を正本とする運用契約を記載
- 組織承認済みpackage indexをBuildKit secretで渡してAPI imageをbuildし、`azd deploy --from-package`でデプロイするtaskを追加

## 確認内容

- `qa-scripts`
- `qa-app`
- `qa-platform`
- approved-index関連テスト
- 隔離したBuildKit builderでのno-cache `linux/arm64` image build
- evalのAzure Monitor workspace raw seriesでAPI server、etcd、CoreDNSを確認

## 注意点

認証が必要なpackage indexは専用taskの対象外です。`uv.lock`はpublic PyPIのURLを維持します。