### PR TITLE
approved-index同期を簡素化してuvバージョン管理を集約

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,7 +11,7 @@ AKS 上の Chaos Engineering ラボ環境。azd でインフラとアプリを�
 - **K8s**: Kustomize (`k8s/`)
 - **依存**: Redis (Managed, Entra ID auth), Application Insights, Prometheus
 - **パッケージ管理**: uv workspace (hostはルート`pyproject.toml`の互換範囲、CIとDockerはその下限に固定、ルート `pyproject.toml` + public PyPI source の `uv.lock`、`python`/`pip` 直接実行禁止)
-- **品質検証**: ruff + ty + pytest → クリーン環境では通常は `uv run --no-project "${PWD}/scripts/tasks.py" sync-dev`、組織承認済み package index を必須とする環境では `uv run --no-project "${PWD}/scripts/tasks.py" sync-dev-approved-index` の後に `uv run --no-project "${PWD}/scripts/tasks.py" qa-app`
+- **品質検証**: ruff + ty + pytest → クリーン環境では通常は `uv run --no-project "${PWD}/scripts/tasks.py" sync-dev` の後に `uv run --no-project "${PWD}/scripts/tasks.py" qa-app`、組織承認済み package index を必須とする環境では `qa-app` が実行前に依存関係を同期する
 - **Bicep 検証**: `uv run --no-project "${PWD}/scripts/tasks.py" build-bicep`。Lefthook の pre-commit は、ステージされた Bicep 変更がある場合に実行する
 - **編集時自動検証**: `.github/hooks/hooks.json` に postToolUse hook を登録。`.py` 編集では project `.venv` の ruff を直接実行し、`.bicep` 編集では `az bicep format` を実行する。変更/失敗時はエージェントへ `additionalContext` でフィードバックする。依存関係の整合性は同期taskとCIが検証する
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
-          version: "0.12.2"
+          resolution-strategy: "lowest"
           python-version: "3.14"
       - name: Check lock consistency
         run: uv lock --check
@@ -34,7 +34,7 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
-          version: "0.12.2"
+          resolution-strategy: "lowest"
           python-version: "3.14"
       - name: Sync deps (dev)
         run: uv run --no-project "${{ github.workspace }}/scripts/tasks.py" sync-dev
@@ -49,7 +49,7 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
-          version: "0.12.2"
+          resolution-strategy: "lowest"
           python-version: "3.14"
       - name: Sync deps (dev)
         run: uv run --no-project "${{ github.workspace }}/scripts/tasks.py" sync-dev
@@ -65,7 +65,7 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
-          version: "0.12.2"
+          resolution-strategy: "lowest"
           python-version: "3.14"
       - name: Sync deps (dev)
         run: uv run --no-project "${{ github.workspace }}/scripts/tasks.py" sync-dev
@@ -80,7 +80,7 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
-          version: "0.12.2"
+          resolution-strategy: "lowest"
           python-version: "3.14"
       - name: Sync deps (dev)
         run: uv run --no-project "${{ github.workspace }}/scripts/tasks.py" sync-dev

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -197,7 +197,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
-          version: "0.12.2"
+          resolution-strategy: "lowest"
 
       - name: Smoke test - Health endpoint
         env:

--- a/.github/workflows/refresh-uv-lock.yml
+++ b/.github/workflows/refresh-uv-lock.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup uv
         uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
         with:
-          version: "0.12.2"
+          resolution-strategy: "lowest"
           python-version: "3.14"
       - name: Refresh lock
         run: uv lock

--- a/README.md
+++ b/README.md
@@ -91,10 +91,9 @@ uv run --no-project "${PWD}/scripts/tasks.py" sync-dev
 uv run --no-project "${PWD}/scripts/tasks.py" qa
 ```
 
-public package registry へ直接接続できず、組織承認済みの Python package index を使う環境では、代わりに次の同期タスクを実行します。
+public package registryへ直接接続できず、組織承認済みのPython package indexを使う環境では、task runnerが検証前に依存関係を同期します。
 
 ```bash
-uv run --no-project "${PWD}/scripts/tasks.py" sync-dev-approved-index
 uv run --no-project "${PWD}/scripts/tasks.py" qa
 ```
 

--- a/docs/adr/017-approved-index-conversion-for-managed-environments.md
+++ b/docs/adr/017-approved-index-conversion-for-managed-environments.md
@@ -10,17 +10,17 @@ Public GitHub repository では public PyPI source の root `uv.lock` を唯一�
 1. Public GitHub repository では public PyPI source の root `uv.lock` を唯一の正本として維持する。
 2. 管理対象環境では、user-level uv configが単一の`[[index]]`と`default = true`を持つことを検査する。index source、find-links、hash検証、TLS検証、projectまたはdependency groupを変更する設定と環境変数がある場合は同期を中止する。exportと後続の`uv run`はroot projectと対象venvの絶対pathへ固定する。
 3. 管理対象環境ではpublic lockのsourceを検査し、`uv export --frozen`で未コミットの一時requirementsへ変換する。変換後のrequirementsも検査してdirect URLを拒否し、registry packageへ`--require-hashes`を適用してapproved-indexから環境を構築する。workspace sourceはindexを介さず参照する。通常環境とは別のuv cacheを使い、過去にpublic PyPIから取得したartifactを再利用しない。approved-indexがpublic lockの許可するbit-identical artifactを提供することを成立条件とする。
-4. sync stateは仮想環境の外に置き、`uv.lock`のSHA-256と状態（in-progressまたはready）を保持する。環境を消去する前にin-progressを書き、同期の開始時と完了時でlockのhashが一致した場合だけreadyへ変更する。ready stateと同じprovenance markerを仮想環境内にも保存し、両者が一致する場合だけ環境を使用する。staleまたはincompleteの場合はfail closedで再同期を要求し、public sourceへ自動fallbackしない。
+4. task runnerが有効なapproved-index設定を検出した場合、各task processの最初のworkspaceコマンドを実行する前に、仮想環境を消去してapproved-indexから同期する。同期開始からtask processの終了までは、対象venvの正規化pathから導出したprocess間lockを保持し、別processによる同じvenvの再構築を防ぐ。同じprocess内の後続コマンドだけは、直前に構築した環境を`--no-sync`で使用する。永続的なsync stateは保存しない。同期の開始時と完了時でlockのhashが異なる場合はコマンドを実行せず、public sourceへ自動fallbackしない。
 5. task runnerはscriptの絶対pathと`uv run --no-project`で起動し、taskのstate検査より前に別のprojectを探索または同期しないようにする。
 6. GitHub Actions、Azure Functions remote build、外部利用者はpublic PyPIを継続して使用する。
 7. Docker buildも同じexportとpip syncを使う。管理対象環境のローカルbuildはbuild argumentでapproved-index modeとconfigのSHA-256を明示し、BuildKit secretでuser-level uv configをmountする。Dockerfileはmountしたconfigのhashを照合し、build modeとhashをdependency layerおよびBuildKit cache mountのkeyへ含める。公開CIにはsecretを渡さない。
-8. uvのhostはルート`pyproject.toml`で定義する単一minor seriesの互換範囲を許可する。CI、Docker、lock更新workflowは互換範囲の下限へexact pinし、再現性を維持する。
+8. uvのhostはルート`pyproject.toml`で定義する単一minor seriesの互換範囲を許可する。GitHub Actionsとlock更新workflowはsetup-uvに互換範囲を読み取らせ、`lowest` resolution strategyで下限を選択する。`azd package api`はDockerfileを直接buildするため、Dockerのuv versionだけは下限を明記し、taskで`pyproject.toml`との一致を検査する。
 9. dependency update時のpublic lockはGitHub Actionsのread-only artifact workflowで生成し、botのcommit permissionまたはwrite permissionを使わない。
 10. ADR-013のroot lock一本化、Dockerのuv sync、post-edit hookの自動sync許可を上記方式へamendする。post-edit hookは依存関係の整合性を判定せず、project venvのruffを直接実行する。uv workspaceによる統一とADR-009/012のdeploy単位分離は維持する。
 
 ## Consequences
 - 管理対象環境は public lock と bit-identical な依存関係を再現できる。
-- 一時 requirements と sync state の管理が増える。approved-index が成立条件を満たさない場合、環境構築は失敗する。
+- 一時requirementsの生成とtask processごとの再同期が必要になる。approved-indexが成立条件を満たさない場合、環境構築は失敗する。
 
 ## 採用しなかった代替案
 - **管理対象環境専用の lock**: 正本が二重化するため採用しない。

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -199,7 +199,7 @@ azd deploy node-provisioning -e eval
 
 ## ローカル開発
 
-リポジトリは uv workspace 構成です。hostはルート`pyproject.toml`の互換範囲に従います。CI、Docker、lock更新workflowは、再現性を維持するため互換範囲の下限へ固定します。`check-uv-version`はこの関係を検査します。ルートで一度同期すれば、`src/api` と `src/external-sli-publisher` の両方の依存と開発ツール (ruff / ty / pytest / locust) が揃います。
+リポジトリはuv workspace構成です。hostはルート`pyproject.toml`の互換範囲に従います。GitHub Actionsとlock更新workflowはsetup-uvで互換範囲の下限を選択します。Dockerのuv versionは`azd package api`との互換性のためDockerfileに明記し、`check-uv-version`がルートの下限との一致を検査します。ルートで一度同期すれば、`src/api`と`src/external-sli-publisher`の両方の依存と開発ツール（ruff、ty、pytest、locust）が揃います。
 
 ```bash
 uv run --no-project "${PWD}/scripts/tasks.py" check-uv-version
@@ -215,15 +215,16 @@ uv run --no-project "${PWD}/scripts/tasks.py" run
 public package registry へ直接接続できない環境では、user-level の uv 設定に組織承認済みの Python package index を一つ構成します。`[[index]]`には`default = true`を指定し、public PyPIへのfallbackを無効にします。index URLや認証情報はリポジトリへ保存しません。
 
 ```bash
-uv run --no-project "${PWD}/scripts/tasks.py" sync-dev-approved-index
 uv run --no-project "${PWD}/scripts/tasks.py" qa-app
 ```
 
-このタスクはuser-level設定とpublic lockのsourceを検査してから、public `uv.lock`を一時requirementsへ変換し、構成済みのpackage indexから`.venv`を作成します。変換後のrequirementsも検査し、direct URL、find-links、hash検証やTLS検証を無効にする設定、projectやdependency groupを変更する環境変数を拒否します。exportと後続の`uv run`はroot projectと対象venvの絶対pathへ固定します。registry packageには`--require-hashes`を適用し、workspace sourceはindexを介さず`.pth`で参照します。通常環境と分離した`.uv-state/cache/`を使い、一時requirementsは処理後に削除します。`.uv-state/`配下のstateは同期した`uv.lock`のSHA-256を記録し、後続のtaskは検証済み環境へ`--no-sync`を適用します。stateを`.venv`の外へ置くため、環境の再作成が中断しても未完了状態が残ります。
+task runnerは有効なapproved-index設定を検出すると、各task processの最初のworkspaceコマンドを実行する前に`.venv`を再構築します。同期開始からtask processの終了までは、対象venvの正規化pathから導出したprocess間lockをOSの一時領域で保持するため、同じvenvを使うworkspace taskは直列に実行されます。明示的に環境だけを準備する場合は`sync-dev-approved-index`を実行します。
+
+同期処理はuser-level設定とpublic lockのsourceを検査してから、public `uv.lock`を一時requirementsへ変換し、構成済みのpackage indexから`.venv`を作成します。変換後のrequirementsも検査し、direct URL、find-links、hash検証やTLS検証を無効にする設定、projectやdependency groupを変更する環境変数を拒否します。exportと後続の`uv run`はroot projectと対象venvの絶対pathへ固定します。registry packageには`--require-hashes`を適用し、workspace sourceはindexを介さず`.pth`で参照します。通常環境と分離した`.uv-state/cache/`を使い、一時requirementsは処理後に削除します。index固有のusernameとpassword環境変数は同期processだけへ渡し、ruff、ty、pytest、アプリなどの後続processから除去します。同じtask process内の後続コマンドだけは、直前に構築した環境へ`--no-sync`を適用します。
 
 post-edit hookは依存関係の整合性を判定しません。Python編集時はprojectの`.venv`にある`ruff`を直接実行し、ruffがない場合は同期を要求します。lockと仮想環境の整合性は同期taskとCIで検証します。
 
-`uv.lock`が変わった場合や同期が中断した場合、taskは古い環境を使わず再同期を要求します。同じコマンドを再実行してください。通常の同期へ戻す場合は`.venv`を削除し、`uv run --no-project "${PWD}/scripts/tasks.py" reset-approved-index-state`を実行してから`sync-dev`を実行します。
+`uv.lock`が同期中に変わった場合や同期が中断した場合、taskは対象コマンドを実行しません。同じコマンドを再実行してください。通常の同期へ戻す場合はuser-levelのapproved-index設定を無効にしてから`sync-dev`を実行します。
 
 task runnerを介さない `uv run` では、projectの自動同期を明示的に止めます。
 
@@ -261,13 +262,13 @@ gh run list --workflow refresh-uv-lock.yml --branch <branch>
 gh run download <run-id> --name uv-lock-public --dir tmp/refresh-uv-lock
 ```
 
-workflowは`pyproject.toml`、`uv.lock`、workflow定義自身を変更したpull requestで実行されます。既定branchへmergeした後は`workflow_dispatch`でも実行できます。取得した`uv.lock`の差分を確認して変更branchへ追加した後、組織承認済みpackage indexを使う環境で`sync-dev-approved-index`を再実行します。package indexがpublic lockと同一hashのartifactを提供できない場合、同期は失敗します。
+workflowは`pyproject.toml`、`uv.lock`、workflow定義自身を変更したpull requestで実行されます。既定branchへmergeした後は`workflow_dispatch`でも実行できます。取得した`uv.lock`の差分を確認して変更branchへ追加すると、組織承認済みpackage indexを使う環境では次のworkspace task実行時に再同期します。package indexがpublic lockと同一hashのartifactを提供できない場合、同期は失敗します。
 
 ## テストと品質確認
 
 アプリケーション:
 
-クリーン環境や新しいworktreeでは、先に通常環境で`uv run --no-project "${PWD}/scripts/tasks.py" sync-dev`、組織承認済みpackage indexを使う環境で`uv run --no-project "${PWD}/scripts/tasks.py" sync-dev-approved-index`を実行してください。絶対pathと`--no-project`は、task runnerの起動前にuvが別のprojectを探索または同期することを防ぎます。`qa-app`は同期済みのworkspace venvを前提にruff、ty、pytestを実行します。
+クリーン環境や新しいworktreeでは、通常環境で`uv run --no-project "${PWD}/scripts/tasks.py" sync-dev`を実行してください。組織承認済みpackage indexを使う環境では、workspaceコマンドを含むtaskが実行前に環境を同期します。絶対pathと`--no-project`は、task runnerの起動前にuvが別のprojectを探索または同期することを防ぎます。
 
 ```bash
 uv run --no-project "${PWD}/scripts/tasks.py" test

--- a/scripts/tasks.py
+++ b/scripts/tasks.py
@@ -6,17 +6,18 @@
 from __future__ import annotations
 
 import hashlib
-import json
+import importlib
 import os
 import re
 import shutil
 import subprocess
 import sys
 import tempfile
+import time
 import tomllib
 from collections.abc import Callable, Sequence
-from contextlib import suppress
 from pathlib import Path
+from typing import BinaryIO
 
 from approved_index_config import (
     UNSAFE_UV_ENVIRONMENT_VARIABLES,
@@ -40,10 +41,10 @@ ACTIONLINT_IMAGE = "rhysd/actionlint:1.7.12"
 KUBECONFORM_IMAGE = "ghcr.io/yannh/kubeconform:v0.7.0"
 K8S_VERSION = "1.33.0"
 KUBECONFORM_SKIP = "VerticalPodAutoscaler,CiliumNetworkPolicy,Kustomization,Gateway,HTTPRoute,Instrumentation"
-APPROVED_INDEX_STATE_DIRECTORY = ".uv-state"
-APPROVED_INDEX_ENVIRONMENT_STATE_FILENAME = ".approved-index-sync.json"
-APPROVED_INDEX_STATE_VERSION = 3
+APPROVED_INDEX_CACHE_DIRECTORY = Path(".uv-state") / "cache"
 API_LOCAL_IMAGE = "aks-chaos-lab:local"
+_approved_index_environment_prepared = False
+_approved_index_lock_file: BinaryIO | None = None
 
 
 def print_step(message: str) -> None:
@@ -73,6 +74,12 @@ def child_env(extra: dict[str, str] | None = None) -> dict[str, str]:
     env.pop("VIRTUAL_ENV", None)
     for name in UNSAFE_UV_ENVIRONMENT_VARIABLES:
         env.pop(name, None)
+    for name in tuple(env):
+        normalized_name = name.upper()
+        if normalized_name.startswith("UV_INDEX_") and normalized_name.endswith(
+            ("_USERNAME", "_PASSWORD")
+        ):
+            env.pop(name, None)
     env.setdefault("PYTHONUTF8", "1")
     if extra:
         env.update(extra)
@@ -87,20 +94,69 @@ def project_environment_path() -> Path:
     return path if path.is_absolute() else ROOT / path
 
 
-def approved_index_state_path() -> Path:
-    environment = str(project_environment_path().resolve())
-    environment_key = hashlib.sha256(environment.encode()).hexdigest()[:16]
+def approved_index_cache_path() -> Path:
+    return ROOT / APPROVED_INDEX_CACHE_DIRECTORY
+
+
+def approved_index_credentials(config_path: Path) -> dict[str, str]:
+    config = tomllib.loads(config_path.read_text(encoding="utf-8"))
+    index_name = config["index"][0]["name"]
+    normalized_name = re.sub(r"[^A-Za-z0-9]", "_", index_name).upper()
+    prefix = f"UV_INDEX_{normalized_name}"
+    return {
+        name: os.environ[name]
+        for name in (f"{prefix}_USERNAME", f"{prefix}_PASSWORD")
+        if name in os.environ
+    }
+
+
+def approved_index_lock_path() -> Path:
+    environment = os.path.normcase(str(project_environment_path().resolve()))
+    environment_key = hashlib.sha256(environment.encode()).hexdigest()
     return (
-        ROOT / APPROVED_INDEX_STATE_DIRECTORY / f"approved-index-{environment_key}.json"
+        Path(tempfile.gettempdir())
+        / "aks-chaos-lab-uv-locks"
+        / f"{environment_key}.lock"
     )
 
 
-def approved_index_cache_path() -> Path:
-    return ROOT / APPROVED_INDEX_STATE_DIRECTORY / "cache"
+def acquire_approved_index_lock() -> None:
+    global _approved_index_lock_file
+
+    if _approved_index_lock_file is not None:
+        return
+
+    lock_path = approved_index_lock_path()
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    lock_file = lock_path.open("a+b")
+    lock_file.seek(0, os.SEEK_END)
+    if lock_file.tell() == 0:
+        lock_file.write(b"\0")
+        lock_file.flush()
+    lock_file.seek(0)
+
+    if os.name == "nt":
+        msvcrt = importlib.import_module("msvcrt").__dict__
+        while True:
+            try:
+                msvcrt["locking"](lock_file.fileno(), msvcrt["LK_NBLCK"], 1)
+                break
+            except OSError:
+                time.sleep(0.1)
+    else:
+        fcntl = importlib.import_module("fcntl").__dict__
+        fcntl["flock"](lock_file.fileno(), fcntl["LOCK_EX"])
+
+    _approved_index_lock_file = lock_file
 
 
-def approved_index_environment_state_path() -> Path:
-    return project_environment_path() / APPROVED_INDEX_ENVIRONMENT_STATE_FILENAME
+def release_approved_index_lock() -> None:
+    global _approved_index_lock_file
+
+    if _approved_index_lock_file is None:
+        return
+    _approved_index_lock_file.close()
+    _approved_index_lock_file = None
 
 
 def lock_sha256() -> str:
@@ -111,86 +167,19 @@ def lock_sha256() -> str:
     return digest.hexdigest()
 
 
-def write_approved_index_state(status: str, lock_digest: str | None = None) -> None:
-    state = {
-        "schema": APPROVED_INDEX_STATE_VERSION,
-        "status": status,
-        "lock_sha256": lock_digest or lock_sha256(),
-    }
-
-    def write_state(state_path: Path) -> None:
-        state_path.parent.mkdir(parents=True, exist_ok=True)
-        temporary_path = state_path.with_suffix(".tmp")
-        temporary_path.write_text(
-            json.dumps(state, indent=2, sort_keys=True) + "\n",
-            encoding="utf-8",
-        )
-        temporary_path.replace(state_path)
-
-    if status == "ready":
-        write_state(approved_index_environment_state_path())
-    state_path = approved_index_state_path()
-    write_state(state_path)
-
-
-def read_approved_index_state() -> dict[str, object] | None:
-    state_path = approved_index_state_path()
-    if not state_path.exists():
-        return None
-    try:
-        state = json.loads(state_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError) as error:
-        print(f"error: Invalid approved-index sync state: {error}", file=sys.stderr)
-        raise SystemExit(1) from error
-    if not isinstance(state, dict):
-        print("error: Invalid approved-index sync state format", file=sys.stderr)
-        raise SystemExit(1)
-    return state
-
-
 def approved_index_run_flags() -> list[str]:
-    state = read_approved_index_state()
-    if state is None:
-        ensure_approved_index_not_selected()
-        return []
-    if (
-        state.get("schema") != APPROVED_INDEX_STATE_VERSION
-        or state.get("status") != "ready"
-    ):
-        print(
-            "error: The approved-index environment is incomplete. "
-            'Run \'uv run --no-project "${PWD}/scripts/tasks.py" '
-            "sync-dev-approved-index'.",
-            file=sys.stderr,
-        )
-        raise SystemExit(1)
-    if state.get("lock_sha256") != lock_sha256():
-        print(
-            "error: uv.lock changed after the approved-index environment was synced. "
-            'Run \'uv run --no-project "${PWD}/scripts/tasks.py" '
-            "sync-dev-approved-index'.",
-            file=sys.stderr,
-        )
-        raise SystemExit(1)
-    environment_state_path = approved_index_environment_state_path()
+    global _approved_index_environment_prepared
+
+    if _approved_index_environment_prepared:
+        return ["--no-sync"]
+
     try:
-        environment_state = json.loads(
-            environment_state_path.read_text(encoding="utf-8")
-        )
-    except (OSError, json.JSONDecodeError) as error:
-        print(
-            f"error: Invalid approved-index environment provenance: {error}",
-            file=sys.stderr,
-        )
-        raise SystemExit(1) from error
-    if environment_state != state:
-        print(
-            "error: The virtual environment does not match its approved-index state. "
-            'Run \'uv run --no-project "${PWD}/scripts/tasks.py" '
-            "sync-dev-approved-index'.",
-            file=sys.stderr,
-        )
-        raise SystemExit(1)
+        config_path = user_uv_config_path()
+        validate_approved_index_config(config_path, environ={})
+    except ApprovedIndexConfigError:
+        return []
+
+    target_sync_dev_approved_index()
     return ["--no-sync"]
 
 
@@ -208,16 +197,6 @@ def ensure_approved_index_not_selected() -> None:
 
 
 def ensure_standard_sync_allowed() -> None:
-    if approved_index_state_path().exists():
-        print(
-            "error: This environment is managed by the approved-index workflow. "
-            'Run \'uv run --no-project "${PWD}/scripts/tasks.py" '
-            "sync-dev-approved-index' "
-            "to refresh it. To return to standard sync, remove the virtual environment "
-            "and run the reset-approved-index-state target.",
-            file=sys.stderr,
-        )
-        raise SystemExit(1)
     ensure_approved_index_not_selected()
 
 
@@ -371,99 +350,94 @@ def target_sync_dev() -> None:
 
 
 def target_sync_dev_approved_index() -> None:
+    global _approved_index_environment_prepared
+
+    _approved_index_environment_prepared = False
+    acquire_approved_index_lock()
+    sync_succeeded = False
     print_step("Syncing workspace dependencies from the approved package index")
-    environment = project_environment_path()
-    config_path = user_uv_config_path()
     try:
-        validate_approved_index_config(config_path)
-    except ApprovedIndexConfigError as error:
-        print(f"error: {error}", file=sys.stderr)
-        raise SystemExit(1) from error
-    lock_digest = lock_sha256()
-    try:
-        validate_public_lock(ROOT / "pyproject.toml", ROOT / "uv.lock")
-    except (OSError, PublicLockError, tomllib.TOMLDecodeError) as error:
-        print(f"error: {error}", file=sys.stderr)
-        raise SystemExit(1) from error
-    write_approved_index_state("in-progress", lock_digest)
-    with tempfile.TemporaryDirectory(prefix="aks-chaos-lab-uv-") as temporary_dir:
-        requirements = Path(temporary_dir) / "requirements.txt"
-        run(
-            [
-                "uv",
-                "venv",
-                "--clear",
-                "--python",
-                "3.14",
-                str(environment),
-            ]
-        )
-        run(
-            [
-                "uv",
-                "export",
-                "--project",
-                str(ROOT),
-                "--quiet",
-                "--frozen",
-                "--all-packages",
-                "--all-groups",
-                "--no-emit-workspace",
-                "--no-emit-index-url",
-                "--output-file",
-                str(requirements),
-            ]
-        )
+        environment = project_environment_path()
         try:
-            validate_exported_requirements(requirements)
-        except (OSError, PublicLockError) as error:
+            config_path = user_uv_config_path()
+            validate_approved_index_config(config_path)
+        except ApprovedIndexConfigError as error:
             print(f"error: {error}", file=sys.stderr)
             raise SystemExit(1) from error
-        run(
-            [
-                "uv",
-                "pip",
-                "sync",
-                "--require-hashes",
-                str(requirements),
-                "--python",
-                str(environment_python_path()),
-            ],
-            env={
-                "UV_CACHE_DIR": str(approved_index_cache_path()),
-                "UV_CONFIG_FILE": str(config_path),
-            },
-        )
-        site_packages = environment_site_packages_path()
-        site_packages.mkdir(parents=True, exist_ok=True)
-        (site_packages / "aks-chaos-lab-workspace.pth").write_text(
-            f"{API_DIR.resolve()}\n{PUBLISHER_DIR.resolve()}\n",
-            encoding="utf-8",
-        )
-    if lock_sha256() != lock_digest:
-        print(
-            "error: uv.lock changed while the approved-index environment was syncing. "
-            "Run the sync target again.",
-            file=sys.stderr,
-        )
-        raise SystemExit(1)
-    write_approved_index_state("ready", lock_digest)
-    print_success("Approved-index development dependencies synced")
-
-
-def target_reset_approved_index_state() -> None:
-    environment = project_environment_path()
-    if environment.exists():
-        print(
-            f"error: Remove the virtual environment first: {environment}",
-            file=sys.stderr,
-        )
-        raise SystemExit(1)
-    state_path = approved_index_state_path()
-    state_path.unlink(missing_ok=True)
-    with suppress(OSError):
-        state_path.parent.rmdir()
-    print_success("Approved-index state reset")
+        lock_digest = lock_sha256()
+        try:
+            validate_public_lock(ROOT / "pyproject.toml", ROOT / "uv.lock")
+        except (OSError, PublicLockError, tomllib.TOMLDecodeError) as error:
+            print(f"error: {error}", file=sys.stderr)
+            raise SystemExit(1) from error
+        with tempfile.TemporaryDirectory(prefix="aks-chaos-lab-uv-") as temporary_dir:
+            requirements = Path(temporary_dir) / "requirements.txt"
+            run(
+                [
+                    "uv",
+                    "venv",
+                    "--clear",
+                    "--python",
+                    "3.14",
+                    str(environment),
+                ]
+            )
+            run(
+                [
+                    "uv",
+                    "export",
+                    "--project",
+                    str(ROOT),
+                    "--quiet",
+                    "--frozen",
+                    "--all-packages",
+                    "--all-groups",
+                    "--no-emit-workspace",
+                    "--no-emit-index-url",
+                    "--output-file",
+                    str(requirements),
+                ]
+            )
+            try:
+                validate_exported_requirements(requirements)
+            except (OSError, PublicLockError) as error:
+                print(f"error: {error}", file=sys.stderr)
+                raise SystemExit(1) from error
+            run(
+                [
+                    "uv",
+                    "pip",
+                    "sync",
+                    "--require-hashes",
+                    str(requirements),
+                    "--python",
+                    str(environment_python_path()),
+                ],
+                env={
+                    "UV_CACHE_DIR": str(approved_index_cache_path()),
+                    "UV_CONFIG_FILE": str(config_path),
+                    **approved_index_credentials(config_path),
+                },
+            )
+            site_packages = environment_site_packages_path()
+            site_packages.mkdir(parents=True, exist_ok=True)
+            (site_packages / "aks-chaos-lab-workspace.pth").write_text(
+                f"{API_DIR.resolve()}\n{PUBLISHER_DIR.resolve()}\n",
+                encoding="utf-8",
+            )
+        if lock_sha256() != lock_digest:
+            print(
+                "error: uv.lock changed while the approved-index environment was syncing. "
+                "Run the sync target again.",
+                file=sys.stderr,
+            )
+            raise SystemExit(1)
+        _approved_index_environment_prepared = True
+        sync_succeeded = True
+        print_success("Approved-index development dependencies synced")
+    finally:
+        if not sync_succeeded:
+            release_approved_index_lock()
 
 
 # ---------------------------------------------------------------------------
@@ -752,6 +726,16 @@ def target_check_uv_version() -> None:
         )
         raise SystemExit(1)
 
+    root_uv_config = ROOT / "uv.toml"
+    if root_uv_config.exists():
+        uv_config = tomllib.loads(root_uv_config.read_text(encoding="utf-8"))
+        if "required-version" in uv_config:
+            print(
+                "error: root uv.toml must not override the workspace required-version",
+                file=sys.stderr,
+            )
+            raise SystemExit(1)
+
     local_version_output = command_output(
         ["uv", "--version"], allow_failure=True, quiet_stderr=True
     )
@@ -768,7 +752,9 @@ def target_check_uv_version() -> None:
     )
     docker_version = docker_match.group(1) if docker_match else "not found"
 
-    workflow_versions: list[tuple[Path, str]] = []
+    workflow_settings: list[
+        tuple[Path, str | None, str | None, str | None, str | None]
+    ] = []
     workflow_paths = sorted(
         (*WORKFLOWS_DIR.glob("*.yml"), *WORKFLOWS_DIR.glob("*.yaml"))
     )
@@ -778,9 +764,12 @@ def target_check_uv_version() -> None:
             if "uses: astral-sh/setup-uv@" not in line:
                 continue
             action_indent = len(line) - len(line.lstrip())
-            pinned_version = "not pinned"
             with_indent: int | None = None
             with_child_indent: int | None = None
+            version: str | None = None
+            version_file: str | None = None
+            resolution_strategy: str | None = None
+            working_directory: str | None = None
             for candidate in lines[index + 1 :]:
                 stripped_candidate = candidate.strip()
                 if not stripped_candidate:
@@ -800,19 +789,35 @@ def target_check_uv_version() -> None:
                     with_child_indent = candidate_indent
                 if candidate_indent != with_child_indent:
                     continue
-                version_match = re.fullmatch(
-                    r"""version:\s*["']?([0-9]+\.[0-9]+\.[0-9]+)["']?""",
-                    stripped_candidate,
+                setting_match = re.match(r"([a-z-]+):(?:\s*(.*))?$", stripped_candidate)
+                if setting_match is None:
+                    continue
+                name, raw_value = setting_match.groups()
+                value = (
+                    (raw_value or "").split(" #", maxsplit=1)[0].strip().strip("\"'")
                 )
-                if version_match is not None:
-                    pinned_version = version_match.group(1)
-                    break
-            workflow_versions.append((workflow_path, pinned_version))
+                if name == "version":
+                    version = value
+                elif name == "version-file":
+                    version_file = value
+                elif name == "resolution-strategy":
+                    resolution_strategy = value
+                elif name == "working-directory":
+                    working_directory = value
+            workflow_settings.append(
+                (
+                    workflow_path,
+                    version,
+                    version_file,
+                    resolution_strategy,
+                    working_directory,
+                )
+            )
 
     print(f"  Required workspace uv:  {required_version}")
     print(f"  Local uv:               {local_version}")
     print(f"  Pinned Docker uv:       {docker_version}")
-    print(f"  Pinned workflow uv:     {minimum_text}")
+    print("  Workflow uv:            pyproject.toml lower bound")
 
     if docker_version != minimum_text:
         print(
@@ -822,12 +827,31 @@ def target_check_uv_version() -> None:
         )
         raise SystemExit(1)
 
-    for workflow_path, workflow_version in workflow_versions:
-        if workflow_version != minimum_text:
+    for (
+        workflow_path,
+        workflow_version,
+        workflow_version_file,
+        resolution_strategy,
+        working_directory,
+    ) in workflow_settings:
+        if workflow_version is not None or workflow_version_file is not None:
             print(
                 f"error: {workflow_path.relative_to(ROOT)} setup-uv "
-                f"({workflow_version}) must remain pinned to "
-                f"the minimum workspace version ({minimum_text})",
+                "must read required-version from the root pyproject.toml",
+                file=sys.stderr,
+            )
+            raise SystemExit(1)
+        if working_directory is not None:
+            print(
+                f"error: {workflow_path.relative_to(ROOT)} setup-uv must resolve "
+                "required-version from the repository root",
+                file=sys.stderr,
+            )
+            raise SystemExit(1)
+        if resolution_strategy != "lowest":
+            print(
+                f"error: {workflow_path.relative_to(ROOT)} setup-uv must set "
+                'resolution-strategy: "lowest"',
                 file=sys.stderr,
             )
             raise SystemExit(1)
@@ -846,7 +870,9 @@ def target_check_uv_version() -> None:
             file=sys.stderr,
         )
         raise SystemExit(1)
-    print_success("Local uv is compatible and reproducible environments remain pinned")
+    print_success(
+        "Local uv is compatible; CI and Docker use the workspace minimum version"
+    )
 
 
 def target_check_public_lock() -> None:
@@ -1159,7 +1185,6 @@ TARGETS: dict[str, Callable[[], None]] = {
     "qa-platform": target_qa_platform,
     "qa-scripts": target_qa_scripts,
     "qa-workflows": target_qa_workflows,
-    "reset-approved-index-state": target_reset_approved_index_state,
     "run": target_run,
     "sync": target_sync,
     "sync-dev": target_sync_dev,

--- a/scripts/tests/test_uv_workflow.py
+++ b/scripts/tests/test_uv_workflow.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import importlib.util
-import json
 import sys
 from pathlib import Path
 from types import ModuleType
@@ -39,9 +38,11 @@ post_edit = load_module(
 def configure_root(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, lock_content: str = "version = 1\n"
 ) -> None:
+    tasks.release_approved_index_lock()
     (tmp_path / "uv.lock").write_text(lock_content, encoding="utf-8")
     monkeypatch.setattr(tasks, "ROOT", tmp_path)
     monkeypatch.setattr(post_edit, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(tasks, "_approved_index_environment_prepared", False)
     monkeypatch.setattr(
         tasks,
         "user_uv_config_path",
@@ -59,65 +60,42 @@ def write_approved_config(
     )
 
 
-def test_ready_state_adds_no_sync(
+def test_approved_index_run_flags_sync_once_per_process(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     configure_root(monkeypatch, tmp_path)
-    (tmp_path / ".venv").mkdir()
+    config_path = tmp_path / "uv.toml"
+    write_approved_config(config_path)
+    monkeypatch.setattr(tasks, "user_uv_config_path", lambda: config_path)
+    sync_calls = 0
+
+    def sync_approved_index() -> None:
+        nonlocal sync_calls
+        sync_calls += 1
+        monkeypatch.setattr(tasks, "_approved_index_environment_prepared", True)
+
     monkeypatch.setattr(
         tasks,
-        "user_uv_config_path",
-        lambda: pytest.fail("ready state must not inspect user config"),
+        "target_sync_dev_approved_index",
+        sync_approved_index,
     )
-
-    tasks.write_approved_index_state("ready")
 
     assert tasks.approved_index_run_flags() == ["--no-sync"]
+    assert tasks.approved_index_run_flags() == ["--no-sync"]
+    assert sync_calls == 1
 
 
-def test_changed_lock_fails_closed(
+def test_approved_index_run_flags_defer_missing_config_path(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     configure_root(monkeypatch, tmp_path)
-    (tmp_path / ".venv").mkdir()
-    tasks.write_approved_index_state("ready")
-    (tmp_path / "uv.lock").write_text("version = 2\n", encoding="utf-8")
 
-    with pytest.raises(SystemExit):
-        tasks.approved_index_run_flags()
+    def missing_config_path() -> Path:
+        raise approved_config.ApprovedIndexConfigError("missing config root")
 
+    monkeypatch.setattr(tasks, "user_uv_config_path", missing_config_path)
 
-def test_missing_environment_provenance_fails_closed(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    configure_root(monkeypatch, tmp_path)
-    (tmp_path / ".venv").mkdir()
-    tasks.write_approved_index_state("ready")
-    tasks.approved_index_environment_state_path().unlink()
-
-    with pytest.raises(SystemExit):
-        tasks.approved_index_run_flags()
-
-
-def test_incomplete_state_fails_closed(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-) -> None:
-    configure_root(monkeypatch, tmp_path)
-    state_path = tasks.approved_index_state_path()
-    state_path.parent.mkdir()
-    state_path.write_text(
-        json.dumps(
-            {
-                "schema": tasks.APPROVED_INDEX_STATE_VERSION,
-                "status": "in-progress",
-                "lock_sha256": tasks.lock_sha256(),
-            }
-        ),
-        encoding="utf-8",
-    )
-
-    with pytest.raises(SystemExit):
-        tasks.approved_index_run_flags()
+    assert tasks.approved_index_run_flags() == []
 
 
 def test_project_environment_honors_relative_override(
@@ -129,15 +107,17 @@ def test_project_environment_honors_relative_override(
     assert tasks.project_environment_path() == tmp_path / "build" / "venv"
 
 
-def test_state_is_stored_outside_virtual_environment(
+def test_approved_index_lock_is_keyed_by_absolute_environment(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     configure_root(monkeypatch, tmp_path)
+    shared_environment = tmp_path / "shared" / ".venv"
+    monkeypatch.setenv("UV_PROJECT_ENVIRONMENT", str(shared_environment))
 
-    state_path = tasks.approved_index_state_path()
+    first_lock = tasks.approved_index_lock_path()
+    monkeypatch.setattr(tasks, "ROOT", tmp_path / "other-worktree")
 
-    assert state_path.parent == tmp_path / tasks.APPROVED_INDEX_STATE_DIRECTORY
-    assert tmp_path / ".venv" not in state_path.parents
+    assert tasks.approved_index_lock_path() == first_lock
 
 
 @pytest.mark.parametrize(
@@ -161,19 +141,6 @@ def test_standard_sync_targets_reject_approved_index(
 
     with pytest.raises(SystemExit):
         getattr(tasks, target_name)()
-
-
-def test_state_free_run_flags_reject_approved_index(
-    monkeypatch: pytest.MonkeyPatch,
-    tmp_path: Path,
-) -> None:
-    configure_root(monkeypatch, tmp_path)
-    config_path = tmp_path / "uv.toml"
-    write_approved_config(config_path)
-    monkeypatch.setattr(tasks, "user_uv_config_path", lambda: config_path)
-
-    with pytest.raises(SystemExit):
-        tasks.approved_index_run_flags()
 
 
 @pytest.mark.parametrize(
@@ -249,7 +216,7 @@ def test_approved_index_config_rejects_source_environment_override(
             )
 
 
-def test_child_environment_removes_unsafe_uv_overrides(
+def test_child_environment_removes_unsafe_uv_overrides_and_credentials(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("UV_PROJECT", "/not-a-project")
@@ -260,7 +227,7 @@ def test_child_environment_removes_unsafe_uv_overrides(
 
     assert "UV_PROJECT" not in environment
     assert "UV_NO_DEV" not in environment
-    assert environment["UV_INDEX_APPROVED_INDEX_USERNAME"] == "username"
+    assert "UV_INDEX_APPROVED_INDEX_USERNAME" not in environment
 
 
 def test_package_api_approved_index_uses_buildkit_secret(
@@ -416,13 +383,17 @@ def test_approved_index_config_rejects_pip_table(tmp_path: Path) -> None:
         approved_config.validate_approved_index_config(config_path, {})
 
 
-def test_lock_change_during_sync_keeps_in_progress_state(
+def test_lock_change_during_sync_fails_before_environment_is_reused(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     configure_root(monkeypatch, tmp_path)
     config_path = tmp_path / "uv.toml"
     write_approved_config(config_path)
     monkeypatch.setattr(tasks, "user_uv_config_path", lambda: config_path)
+    monkeypatch.setattr(tasks, "acquire_approved_index_lock", lambda: None)
+    monkeypatch.setenv("UV_INDEX_APPROVED_INDEX_USERNAME", "username")
+    monkeypatch.setenv("UV_INDEX_APPROVED_INDEX_PASSWORD", "password")
+    monkeypatch.setenv("UV_INDEX_OTHER_PASSWORD", "other-password")
     monkeypatch.setattr(tasks, "validate_public_lock", lambda *_args: None)
     monkeypatch.setattr(
         tasks,
@@ -445,21 +416,23 @@ def test_lock_change_during_sync_keeps_in_progress_state(
     with pytest.raises(SystemExit):
         tasks.target_sync_dev_approved_index()
 
-    state = json.loads(tasks.approved_index_state_path().read_text(encoding="utf-8"))
-    assert state["status"] == "in-progress"
+    assert tasks.__dict__["_approved_index_environment_prepared"] is False
     assert pip_environment == {
         "UV_CACHE_DIR": str(tasks.approved_index_cache_path()),
         "UV_CONFIG_FILE": str(config_path),
+        "UV_INDEX_APPROVED_INDEX_USERNAME": "username",
+        "UV_INDEX_APPROVED_INDEX_PASSWORD": "password",
     }
 
 
-def test_environment_creation_failure_keeps_in_progress_state(
+def test_environment_creation_failure_does_not_mark_process_prepared(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:
     configure_root(monkeypatch, tmp_path)
     config_path = tmp_path / "uv.toml"
     write_approved_config(config_path)
     monkeypatch.setattr(tasks, "user_uv_config_path", lambda: config_path)
+    monkeypatch.setattr(tasks, "acquire_approved_index_lock", lambda: None)
     monkeypatch.setattr(tasks, "validate_public_lock", lambda *_args: None)
 
     def fail_environment_creation(_args: list[str], **_kwargs: object) -> None:
@@ -470,8 +443,7 @@ def test_environment_creation_failure_keeps_in_progress_state(
     with pytest.raises(RuntimeError, match="simulated interruption"):
         tasks.target_sync_dev_approved_index()
 
-    state = json.loads(tasks.approved_index_state_path().read_text(encoding="utf-8"))
-    assert state["status"] == "in-progress"
+    assert tasks.__dict__["_approved_index_environment_prepared"] is False
 
 
 def test_public_lock_rejects_direct_url_source(
@@ -540,7 +512,7 @@ def test_check_uv_version_allows_compatible_host_patch(
         "steps:\n"
         "  - uses: astral-sh/setup-uv@sha\n"
         "    with:\n"
-        '      version: "0.12.2"\n',
+        '      resolution-strategy: "lowest"\n',
         encoding="utf-8",
     )
     monkeypatch.setattr(tasks, "API_DIR", api_dir)
@@ -582,7 +554,7 @@ def test_check_uv_version_requires_pinned_docker_version(
         "steps:\n"
         "  - uses: astral-sh/setup-uv@sha\n"
         "    with:\n"
-        '      version: "0.12.2"\n',
+        '      resolution-strategy: "lowest"\n',
         encoding="utf-8",
     )
     monkeypatch.setattr(tasks, "API_DIR", api_dir)
@@ -593,8 +565,21 @@ def test_check_uv_version_requires_pinned_docker_version(
         tasks.target_check_uv_version()
 
 
-def test_check_uv_version_requires_pinned_workflow_version(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+@pytest.mark.parametrize(
+    "workflow_settings",
+    (
+        '      version: "0.12.2"\n      resolution-strategy: "lowest"\n',
+        '      version: "0.12.2" # explicit pin\n      resolution-strategy: "lowest"\n',
+        '      version-file: "pyproject.toml"\n      resolution-strategy: "lowest"\n',
+        '      resolution-strategy: "highest"\n',
+        '      resolution-strategy: "lowest"\n      working-directory: "src/api"\n',
+        "",
+    ),
+)
+def test_check_uv_version_requires_workflow_to_resolve_pyproject_lower_bound(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    workflow_settings: str,
 ) -> None:
     configure_root(monkeypatch, tmp_path)
     (tmp_path / "pyproject.toml").write_text(
@@ -610,28 +595,13 @@ def test_check_uv_version_requires_pinned_workflow_version(
     workflow_path = tmp_path / ".github" / "workflows" / "ci.yml"
     workflow_path.parent.mkdir(parents=True)
     workflow_path.write_text(
-        "steps:\n"
-        "  - uses: astral-sh/setup-uv@sha\n"
-        "    with:\n"
-        '      version: "0.12.3"\n',
+        f"steps:\n  - uses: astral-sh/setup-uv@sha\n    with:\n{workflow_settings}",
         encoding="utf-8",
     )
     monkeypatch.setattr(tasks, "API_DIR", api_dir)
     monkeypatch.setattr(tasks, "WORKFLOWS_DIR", workflow_path.parent)
     monkeypatch.setattr(tasks, "command_output", lambda *args, **kwargs: "uv 0.12.3")
 
-    with pytest.raises(SystemExit):
-        tasks.target_check_uv_version()
-
-    workflow_path.write_text(
-        "steps:\n"
-        "  - uses: astral-sh/setup-uv@sha\n"
-        "    env:\n"
-        '      version: "0.12.2"\n'
-        "    with:\n"
-        '      version-file: "pyproject.toml"\n',
-        encoding="utf-8",
-    )
     with pytest.raises(SystemExit):
         tasks.target_check_uv_version()
 
@@ -642,6 +612,23 @@ def test_check_uv_version_requires_one_minor_compatibility_range(
     configure_root(monkeypatch, tmp_path)
     (tmp_path / "pyproject.toml").write_text(
         '[tool.uv]\nrequired-version = "==0.12.2"\n',
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit):
+        tasks.target_check_uv_version()
+
+
+def test_check_uv_version_rejects_root_uv_toml_version_override(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    configure_root(monkeypatch, tmp_path)
+    (tmp_path / "pyproject.toml").write_text(
+        '[tool.uv]\nrequired-version = ">=0.12.2,<0.13.0"\n',
+        encoding="utf-8",
+    )
+    (tmp_path / "uv.toml").write_text(
+        'required-version = ">=0.12.3,<0.13.0"\n',
         encoding="utf-8",
     )
 


### PR DESCRIPTION
## 背景

管理対象環境のapproved-index同期は、安全性を維持するために永続的なstate markerとvenv内外のprovenance検査を行っていました。一方で、状態遷移、reset手順、stale判定が実装と運用を複雑にしていました。

## 変更内容

- 永続的なsync stateを廃止し、各task processの最初のworkspace command前にapproved-indexから環境を再構築します。同一process内の後続commandだけ`--no-sync`で再利用します。
- 対象venvの正規化pathから導出したOS file lockをprocess終了まで保持し、複数processやworktreeによる同一venvの並行再構築を防ぎます。
- public lock、SHA-256 hash検証、approved-index専用cache、public fallback拒否は維持します。
- index固有のusername/passwordは`uv pip sync`だけへ渡し、ruff、ty、pytest、アプリなどの後続processから除去します。
- GitHub Actionsのsetup-uvはroot `pyproject.toml`の`required-version`を`lowest` strategyで解決します。`azd package api`との互換性のためDockerのexact versionだけは残し、taskで下限との一致を検査します。
- README、ADR-017、デプロイ手順、Copilot instructionsを新しいフローへ更新します。

## レビュー上の注意

managed環境ではtask processを起動するたびにvenvを再構築します。cacheによりdownloadは再利用しますが、永続stateを使っていた従来方式よりinstall時間は増えます。

## 確認

- approved-index経由の`qa-app`
- ruff、ty
- API unit tests 65件
- external SLI publisher tests 15件
- approved-index workflow tests 34件
- GitHub Actions workflow lint
- security reviewでfindingなし